### PR TITLE
Some build fixes for GCC 13.2.0 and Clang 18.1.1

### DIFF
--- a/src/audio_core/openal_sink.cpp
+++ b/src/audio_core/openal_sink.cpp
@@ -73,8 +73,9 @@ OpenALSink::OpenALSink(std::string device_name) : impl(std::make_unique<Impl>())
 
     auto alBufferCallbackSOFT =
         reinterpret_cast<LPALBUFFERCALLBACKSOFT>(alGetProcAddress("alBufferCallbackSOFT"));
-    alBufferCallbackSOFT(impl->buffer, AL_FORMAT_STEREO16, native_sample_rate, &Impl::Callback,
-                         impl.get());
+    alBufferCallbackSOFT(impl->buffer, AL_FORMAT_STEREO16, native_sample_rate,
+                         reinterpret_cast<ALBUFFERCALLBACKTYPESOFT>(&Impl::Callback), impl.get());
+
     if (alGetError() != AL_NO_ERROR) {
         LOG_CRITICAL(Audio_Sink, "alBufferCallbackSOFT failed: {}", alGetError());
         Close();

--- a/src/citra_qt/util/graphics_device_info.cpp
+++ b/src/citra_qt/util/graphics_device_info.cpp
@@ -22,7 +22,7 @@ QString GetOpenGLRenderer() {
     QOpenGLContext context;
     if (context.create()) {
         context.makeCurrent(&surface);
-        return QString::fromUtf8(context.functions()->glGetString(GL_RENDERER));
+        return QString::fromUtf8(reinterpret_cast<const char*>(context.functions()->glGetString(GL_RENDERER)));
     } else {
         return QStringLiteral("");
     }

--- a/src/citra_qt/util/graphics_device_info.cpp
+++ b/src/citra_qt/util/graphics_device_info.cpp
@@ -22,7 +22,8 @@ QString GetOpenGLRenderer() {
     QOpenGLContext context;
     if (context.create()) {
         context.makeCurrent(&surface);
-        return QString::fromUtf8(reinterpret_cast<const char*>(context.functions()->glGetString(GL_RENDERER)));
+        return QString::fromUtf8(
+            reinterpret_cast<const char*>(context.functions()->glGetString(GL_RENDERER)));
     } else {
         return QStringLiteral("");
     }

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -2251,7 +2251,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
     socklen_t s_info_len = sizeof(struct sockaddr_in);
     sockaddr_in s_info;
 
-    if ((sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+	if (static_cast<int>(sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         return std::nullopt;
     }
 
@@ -2269,7 +2269,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
 
 #ifdef _WIN32
     sock_fd = WSASocket(AF_INET, SOCK_DGRAM, 0, 0, 0, 0);
-    if (sock_fd == SOCKET_ERROR) {
+    if (static_cast<int>(sock_fd) == SOCKET_ERROR) {
         return std::nullopt;
     }
 

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -2251,7 +2251,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
     socklen_t s_info_len = sizeof(struct sockaddr_in);
     sockaddr_in s_info;
 
-	if (static_cast<int>(sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+    if (static_cast<int>(sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
Mostly to do with casting. Encountered them when I was trying to upgrade some of the submodules. Fixes #39. 