### PR TITLE
Reduce log levels for some FS functions and stub cache svcs

### DIFF
--- a/src/core/file_sys/archive_extsavedata.cpp
+++ b/src/core/file_sys/archive_extsavedata.cpp
@@ -128,14 +128,14 @@ public:
             LOG_CRITICAL(Service_FS, "(unreachable) Invalid mount point {}", mount_point);
             return ResultFileNotFound;
         case PathParser::PathNotFound:
-            LOG_ERROR(Service_FS, "Path not found {}", full_path);
+            LOG_DEBUG(Service_FS, "Path not found {}", full_path);
             return ResultPathNotFound;
         case PathParser::FileInPath:
         case PathParser::DirectoryFound:
-            LOG_ERROR(Service_FS, "Unexpected file or directory in {}", full_path);
+            LOG_DEBUG(Service_FS, "Unexpected file or directory in {}", full_path);
             return ResultUnexpectedFileOrDirectory;
         case PathParser::NotFound:
-            LOG_ERROR(Service_FS, "{} not found", full_path);
+            LOG_DEBUG(Service_FS, "{} not found", full_path);
             return ResultFileNotFound;
         case PathParser::FileFound:
             break; // Expected 'success' case

--- a/src/core/file_sys/archive_sdmc.cpp
+++ b/src/core/file_sys/archive_sdmc.cpp
@@ -83,14 +83,14 @@ ResultVal<std::unique_ptr<FileBackend>> SDMCArchive::OpenFileBase(const Path& pa
         return ResultNotFound;
     case PathParser::PathNotFound:
     case PathParser::FileInPath:
-        LOG_ERROR(Service_FS, "Path not found {}", full_path);
+        LOG_DEBUG(Service_FS, "Path not found {}", full_path);
         return ResultNotFound;
     case PathParser::DirectoryFound:
-        LOG_ERROR(Service_FS, "{} is not a file", full_path);
+        LOG_DEBUG(Service_FS, "{} is not a file", full_path);
         return ResultUnexpectedFileOrDirectorySdmc;
     case PathParser::NotFound:
         if (!mode.create_flag) {
-            LOG_ERROR(Service_FS, "Non-existing file {} can't be open without mode create.",
+            LOG_DEBUG(Service_FS, "Non-existing file {} can't be open without mode create.",
                       full_path);
             return ResultNotFound;
         } else {
@@ -348,10 +348,10 @@ ResultVal<std::unique_ptr<DirectoryBackend>> SDMCArchive::OpenDirectory(const Pa
     case PathParser::PathNotFound:
     case PathParser::NotFound:
     case PathParser::FileFound:
-        LOG_ERROR(Service_FS, "{} not found", full_path);
+        LOG_DEBUG(Service_FS, "{} not found", full_path);
         return ResultNotFound;
     case PathParser::FileInPath:
-        LOG_ERROR(Service_FS, "Unexpected file in path {}", full_path);
+        LOG_DEBUG(Service_FS, "Unexpected file in path {}", full_path);
         return ResultUnexpectedFileOrDirectorySdmc;
     case PathParser::DirectoryFound:
         break; // Expected 'success' case

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -396,6 +396,9 @@ private:
                                 s64 nano_seconds);
     Result ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
                            Handle reply_target);
+    Result InvalidateProcessDataCache(Handle process_handle, VAddr address, u32 size);
+    Result StoreProcessDataCache(Handle process_handle, VAddr address, u32 size);
+    Result FlushProcessDataCache(Handle process_handle, VAddr address, u32 size);
     Result CreateAddressArbiter(Handle* out_handle);
     Result ArbitrateAddress(Handle handle, u32 address, u32 type, u32 value, s64 nanoseconds);
     void Break(u8 break_reason);
@@ -1016,6 +1019,39 @@ Result SVC::ReplyAndReceive(s32* index, VAddr handles_address, s32 handle_count,
     // signal in one of its wait objects, or to 0xC8A01836 if there was a translation error.
     // By default the index is set to -1.
     *index = -1;
+    return ResultSuccess;
+}
+
+/// Invalidates the specified cache range (stubbed as we do not emulate cache).
+Result SVC::InvalidateProcessDataCache(Handle process_handle, VAddr address, u32 size) {
+    const std::shared_ptr<Process> process =
+        kernel.GetCurrentProcess()->handle_table.Get<Process>(process_handle);
+    R_UNLESS(process, ResultInvalidHandle);
+
+    LOG_DEBUG(Kernel_SVC, "called address=0x{:08X}, size=0x{:08X}", address, size);
+
+    return ResultSuccess;
+}
+
+/// Stores the specified cache range (stubbed as we do not emulate cache).
+Result SVC::StoreProcessDataCache(Handle process_handle, VAddr address, u32 size) {
+    const std::shared_ptr<Process> process =
+        kernel.GetCurrentProcess()->handle_table.Get<Process>(process_handle);
+    R_UNLESS(process, ResultInvalidHandle);
+
+    LOG_DEBUG(Kernel_SVC, "called address=0x{:08X}, size=0x{:08X}", address, size);
+
+    return ResultSuccess;
+}
+
+/// Flushes the specified cache range (stubbed as we do not emulate cache).
+Result SVC::FlushProcessDataCache(Handle process_handle, VAddr address, u32 size) {
+    const std::shared_ptr<Process> process =
+        kernel.GetCurrentProcess()->handle_table.Get<Process>(process_handle);
+    R_UNLESS(process, ResultInvalidHandle);
+
+    LOG_DEBUG(Kernel_SVC, "called address=0x{:08X}, size=0x{:08X}", address, size);
+
     return ResultSuccess;
 }
 
@@ -2157,9 +2193,9 @@ const std::array<SVC::FunctionDef, 180> SVC::SVC_Table{{
     {0x4F, &SVC::Wrap<&SVC::ReplyAndReceive>, "ReplyAndReceive"},
     {0x50, nullptr, "BindInterrupt"},
     {0x51, nullptr, "UnbindInterrupt"},
-    {0x52, nullptr, "InvalidateProcessDataCache"},
-    {0x53, nullptr, "StoreProcessDataCache"},
-    {0x54, nullptr, "FlushProcessDataCache"},
+    {0x52, &SVC::Wrap<&SVC::InvalidateProcessDataCache>, "InvalidateProcessDataCache"},
+    {0x53, &SVC::Wrap<&SVC::StoreProcessDataCache>, "StoreProcessDataCache"},
+    {0x54, &SVC::Wrap<&SVC::FlushProcessDataCache>, "FlushProcessDataCache"},
     {0x55, nullptr, "StartInterProcessDma"},
     {0x56, nullptr, "StopDma"},
     {0x57, nullptr, "GetDmaState"},

--- a/src/core/hle/service/fs/file.cpp
+++ b/src/core/hle/service/fs/file.cpp
@@ -62,7 +62,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
     const FileSessionSlot* file = GetSessionData(ctx.Session());
 
     if (file->subfile && length > file->size) {
-        LOG_WARNING(Service_FS, "Trying to read beyond the subfile size, truncating");
+        LOG_DEBUG(Service_FS, "Trying to read beyond the subfile size, truncating");
         length = static_cast<u32>(file->size);
     }
 
@@ -70,7 +70,7 @@ void File::Read(Kernel::HLERequestContext& ctx) {
     offset += file->offset;
 
     if (offset + length > backend->GetSize()) {
-        LOG_ERROR(Service_FS,
+        LOG_DEBUG(Service_FS,
                   "Reading from out of bounds offset=0x{:x} length=0x{:08X} file_size=0x{:x}",
                   offset, length, backend->GetSize());
     }

--- a/src/core/hle/service/fs/fs_user.cpp
+++ b/src/core/hle/service/fs/fs_user.cpp
@@ -121,7 +121,7 @@ void FS_USER::OpenFileDirectly(Kernel::HLERequestContext& ctx) {
         rb.PushMoveObjects(file->Connect());
     } else {
         rb.PushMoveObjects<Kernel::Object>(nullptr);
-        LOG_ERROR(Service_FS, "failed to get a handle for file {} mode={} attributes={}",
+        LOG_DEBUG(Service_FS, "failed to get a handle for file {} mode={} attributes={}",
                   file_path.DebugStr(), mode.hex, attributes);
     }
 
@@ -301,7 +301,7 @@ void FS_USER::OpenDirectory(Kernel::HLERequestContext& ctx) {
         directory->ClientConnected(server);
         rb.PushMoveObjects(client);
     } else {
-        LOG_ERROR(Service_FS, "failed to get a handle for directory type={} size={} data={}",
+        LOG_DEBUG(Service_FS, "failed to get a handle for directory type={} size={} data={}",
                   dirname_type, dirname_size, dir_path.DebugStr());
         rb.PushMoveObjects<Kernel::Object>(nullptr);
     }


### PR DESCRIPTION
Some FS functions were constantly throwing errors for missing files. Those are completely normal as it's just games checking if files exist by opening them, and were confusing some people, so the log level was reduced to Debug.

Stubbed some missing cache SVCs that are used commonly in homebrew apps and were throwing many errors.