### PR TITLE
y2r: Delay completion event

### DIFF
--- a/src/core/hle/service/cam/y2r_u.h
+++ b/src/core/hle/service/cam/y2r_u.h
@@ -349,11 +349,13 @@ private:
     Core::System& system;
 
     std::shared_ptr<Kernel::Event> completion_event;
+    Core::TimingEventType* completion_signal_event;
     ConversionConfiguration conversion{};
     DitheringWeightParams dithering_weight_params{};
     bool temporal_dithering_enabled = false;
     bool transfer_end_interrupt_enabled = false;
     bool spacial_dithering_enabled = false;
+    bool is_busy_conversion = false;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);


### PR DESCRIPTION
The FIFA games have a bug in their code and rely on the Y2R decoding event not being signaled immediately. This PR adds the minimum delay I've found to fix the softlock and also implements IsBusyConversion.

Citra (PR) | Citra (master)
-|-
![image](https://github.com/PabloMK7/citra/assets/47210458/9dd70c6c-61c8-4547-ac55-fb88d3762e7c) | ![image](https://github.com/PabloMK7/citra/assets/47210458/587239a2-2fc1-44fb-ad06-e197dea6a685)