### PR TITLE
vk_instance.cpp: fix getting driver_id for vulkan device

### DIFF
--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -407,8 +407,14 @@ bool Instance::CreateDevice() {
         vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR>();
     const vk::StructureChain properties_chain =
         physical_device.getProperties2<vk::PhysicalDeviceProperties2,
+                                       vk::PhysicalDeviceDriverProperties,
                                        vk::PhysicalDevicePortabilitySubsetPropertiesKHR,
                                        vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
+    const vk::PhysicalDeviceDriverProperties driver =
+            properties_chain.get<vk::PhysicalDeviceDriverProperties>();
+
+    driver_id = driver.driverID;
+    vendor_name = driver.driverName.data();
 
     features = feature_chain.get().features;
     if (available_extensions.empty()) {

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -406,12 +406,12 @@ bool Instance::CreateDevice() {
         vk::PhysicalDevicePipelineCreationCacheControlFeaturesEXT,
         vk::PhysicalDeviceFragmentShaderBarycentricFeaturesKHR>();
     const vk::StructureChain properties_chain =
-        physical_device.getProperties2<vk::PhysicalDeviceProperties2,
-                                       vk::PhysicalDeviceDriverProperties,
-                                       vk::PhysicalDevicePortabilitySubsetPropertiesKHR,
-                                       vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
+        physical_device
+            .getProperties2<vk::PhysicalDeviceProperties2, vk::PhysicalDeviceDriverProperties,
+                            vk::PhysicalDevicePortabilitySubsetPropertiesKHR,
+                            vk::PhysicalDeviceExternalMemoryHostPropertiesEXT>();
     const vk::PhysicalDeviceDriverProperties driver =
-            properties_chain.get<vk::PhysicalDeviceDriverProperties>();
+        properties_chain.get<vk::PhysicalDeviceDriverProperties>();
 
     driver_id = driver.driverID;
     vendor_name = driver.driverName.data();


### PR DESCRIPTION
This should resolve #66. I have not been able to test this on non macOS devices. This code was initially in CollectTelemetryParameters() but was removed in commit 0288877. I have re-added it to the CreateDevice function.