### PR TITLE
rasterizer_cache: Improve validation skip heuristic

### DIFF
--- a/src/video_core/rasterizer_cache/rasterizer_cache_base.h
+++ b/src/video_core/rasterizer_cache/rasterizer_cache_base.h
@@ -193,9 +193,6 @@ private:
     bool ValidateByReinterpretation(Surface& surface, SurfaceParams params,
                                     const SurfaceInterval& interval);
 
-    /// Return true if a surface with an invalid pixel format exists at the interval
-    bool IntervalHasInvalidPixelFormat(const SurfaceParams& params, SurfaceInterval interval);
-
     /// Create a new surface
     SurfaceId CreateSurface(const SurfaceParams& params);
 


### PR DESCRIPTION
Most 3DS game are relatively well behaved with their VRAM usage, with few framebuffers that don't overlap with each others. However since the system has UMA architecture, nothing stops games from using VRAM in weird ways. In some cases games will try to reuse VRAM by aliasing memory as entirely different textures. This isn't that terrible to handle if the stride stays the same, something that isn't always true.

Luigi's Mansion: Dark Moon will initially use a memory region as a framebuffer with 256 pixel stride, then reuse the same region as a framebuffer with 128 pixel stride. The contents are immediately cleared afterwards so the result doesn't really matter, but this trips up the texture cache and causes a useless and expensive gpu flush per frame.

Kid Icarus also does this. Through the texture cache it shows as various reinterpretations between D24S8 and RGBA8 framebuffers with varying strides. Paper Mario: Sticker Star uses this trick to presumably render the bottom screen. It starts out with 2 color/depth framebuffers with 256 pixel strides and will then reinterpret them as 128, instead of reuse the top framebuffer with a smaller viewport, causing 2 texture flushes per frame.

Arguably the worst case of this aliasing is Spider-Man Edge of Time. I haven't measured how many flushes it causes, but it's probably more than 3 and all of them slow down the game to a crawl making in unplayable.

Citra isn't entirely helpless on that front however. The current heuristic will skip validation if part of the interval is owned by a gpu invalid surface and there is a fill surface overlapping that region: https://github.com/PabloMK7/citra/blob/f5cf180cee82ee901d796b2936ce1c1d90f2415d/src/video_core/rasterizer_cache/rasterizer_cache.h#L1185

However this heuristic is kinda busted and just happens to work by luck from what I've seen. So in this PR, I have tweaked the heuristic to consider texture strides as well. If the region is partially owned by a gpu invalidated surface that doesn't have the same stride, validation is skipped. This covers a lot of games, but not all (see the comment). In the near future I want to rewrite the validation portion of the code to fully handle texture flushes in the gpu which will allow arbitrary transforms to occur without round-tripping to the cpu.

(Without going into too much detail, the current validation routine in the texture cache suffers from high overhead and lack of flexibility in regards to validation. It will try to find specific surfaces and it if fails, it doesn't consider alternative ways of salvaging gpu data that could be otherwise very usable. A better approach would be to treat validation as a memory operation more like an image copy, with image copies being an optimization for validations that satisfy rectangular bounds)

All in all, this results in a 2x to 4x performance improvements in the games affected. The below tests were carried on my AMD iGPU at 4x resolution to simulate a more GPU bound scenario
| Citra (master) | Citra (PR) 
-|-
![dark_slow](https://github.com/PabloMK7/citra/assets/47210458/74efbf80-a911-4d57-9b89-3e23f64efae1) | ![dark_fast](https://github.com/PabloMK7/citra/assets/47210458/cb60d8c0-e44d-48c0-90df-92c261eccf54)
![kid_slow](https://github.com/PabloMK7/citra/assets/47210458/c6790c2e-3e3a-4ecb-ba84-155e84873138) | ![kid_fast](https://github.com/PabloMK7/citra/assets/47210458/2139a503-4b6e-4a42-8323-57d29cad05a0)
![paper_slow](https://github.com/PabloMK7/citra/assets/47210458/44d0adeb-8792-4285-97b7-d915d8ba6072) | ![paper_fast](https://github.com/PabloMK7/citra/assets/47210458/c9c6768b-8a0c-4398-8cf3-ed0599fa8dd6)
![spider_slow](https://github.com/PabloMK7/citra/assets/47210458/fb3e5d92-1bf4-477f-8560-eaf0a61107f6) | ![spider_fast](https://github.com/PabloMK7/citra/assets/47210458/f655ff8b-0cdc-4197-9cf8-a6cbce53590d)
