### PR TITLE
Use port 5543 by default for Artic Base connections if none is specified

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
@@ -102,6 +102,8 @@ class HomeSettingsFragment : Fragment() {
                             .setTitle(getString(R.string.artic_base_enter_address))
                             .setPositiveButton(android.R.string.ok) { _, _ ->
                                 if (textInputValue.isNotEmpty()) {
+                                    if (!textInputValue.contains(":"))
+                                        textInputValue += ":5543"
                                     val menu = Game(
                                         title = getString(R.string.artic_base),
                                         path = "articbase://$textInputValue",

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -1797,6 +1797,8 @@ void GMainWindow::OnMenuConnectArticBase() {
                                      tr("Enter Artic Base server address:"), QLineEdit::Normal,
                                      UISettings::values.last_artic_base_addr, &ok);
     if (ok) {
+        if (!res.contains(QString::fromStdString(":")))
+            res += QString::fromStdString(":5543");
         UISettings::values.last_artic_base_addr = res;
         BootGame(QString::fromStdString("articbase://").append(res));
     }


### PR DESCRIPTION
This pull request adds logic which checks the entered address when initiating a connection with an Artic Base server, and if no port has been specified, port 5543 is used by default (the default port for Artic Base)