### PR TITLE
Android: Remember last entered Artic Base server address

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
@@ -89,7 +89,7 @@ class HomeSettingsFragment : Fragment() {
                 {
                     val inflater = LayoutInflater.from(context)
                     val inputBinding = DialogSoftwareKeyboardBinding.inflate(inflater)
-                    var textInputValue: String = preferences.getString("lastArticBaseAddr", "")!!
+                    var textInputValue: String = preferences.getString("last_artic_base_addr", "")!!
 
                     inputBinding.editTextInput.setText(textInputValue)
                     inputBinding.editTextInput.doOnTextChanged { text, _, _, _ ->
@@ -103,7 +103,7 @@ class HomeSettingsFragment : Fragment() {
                             .setPositiveButton(android.R.string.ok) { _, _ ->
                                 if (textInputValue.isNotEmpty()) {
                                     preferences.edit()
-                                        .putString("lastArticBaseAddr", textInputValue)
+                                        .putString("last_artic_base_addr", textInputValue)
                                         .apply()
                                     val menu = Game(
                                         title = getString(R.string.artic_base),

--- a/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/fragments/HomeSettingsFragment.kt
@@ -89,7 +89,7 @@ class HomeSettingsFragment : Fragment() {
                 {
                     val inflater = LayoutInflater.from(context)
                     val inputBinding = DialogSoftwareKeyboardBinding.inflate(inflater)
-                    var textInputValue: String = ""
+                    var textInputValue: String = preferences.getString("lastArticBaseAddr", "")!!
 
                     inputBinding.editTextInput.setText(textInputValue)
                     inputBinding.editTextInput.doOnTextChanged { text, _, _, _ ->
@@ -102,6 +102,9 @@ class HomeSettingsFragment : Fragment() {
                             .setTitle(getString(R.string.artic_base_enter_address))
                             .setPositiveButton(android.R.string.ok) { _, _ ->
                                 if (textInputValue.isNotEmpty()) {
+                                    preferences.edit()
+                                        .putString("lastArticBaseAddr", textInputValue)
+                                        .apply()
                                     val menu = Game(
                                         title = getString(R.string.artic_base),
                                         path = "articbase://$textInputValue",


### PR DESCRIPTION
When entering an address for an Artic Base server, the default value will be the address which was last entered

This is a feature which is already present on the desktop build, however it is currently absent in the mobile build