### PR TITLE
Run screenshot capture function in paused state by capturing next frame

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2412,10 +2412,14 @@ void GMainWindow::OnCaptureScreenshot() {
         return;
     }
 
-    if (emu_thread->IsRunning()
-    || (QMessageBox::question(this, tr("Game will unpause"),
-                                 tr("The game will be unpaused, and the next frame will be captured. Is this okay?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)) {
-        if (emu_thread->IsRunning()) {
+    const bool was_running = emu_thread->IsRunning();
+
+    if (was_running ||
+       (QMessageBox::question(
+             this, tr("Game will unpause"),
+             tr("The game will be unpaused, and the next frame will be captured. Is this okay?"),
+             QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)) {
+        if (was_running) {
             OnPauseGame();
         }
         std::string path = UISettings::values.screenshot_path.GetValue();
@@ -2432,13 +2436,16 @@ void GMainWindow::OnCaptureScreenshot() {
 
         static QRegularExpression expr(QStringLiteral("[\\/:?\"<>|]"));
         const std::string filename = game_title.remove(expr).toStdString();
-        const std::string timestamp =
-            QDateTime::currentDateTime().toString(QStringLiteral("dd.MM.yy_hh.mm.ss.z")).toStdString();
+        const std::string timestamp = QDateTime::currentDateTime()
+                                          .toString(QStringLiteral("dd.MM.yy_hh.mm.ss.z"))
+                                          .toStdString();
         path.append(fmt::format("/{}_{}.png", filename, timestamp));
 
-        auto* const screenshot_window = secondary_window->HasFocus() ? secondary_window : render_window;
-        screenshot_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor.GetValue(),
-                                             QString::fromStdString(path));
+        auto* const screenshot_window =
+            secondary_window->HasFocus() ? secondary_window : render_window;
+        screenshot_window->CaptureScreenshot(
+            UISettings::values.screenshot_resolution_factor.GetValue(),
+            QString::fromStdString(path));
         OnStartGame();
     }
 }

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -970,7 +970,7 @@ void GMainWindow::UpdateMenuState() {
         action->setEnabled(emulation_running);
     }
 
-    ui->action_Capture_Screenshot->setEnabled(emulation_running && !is_paused);
+    ui->action_Capture_Screenshot->setEnabled(emulation_running);
 
     if (emulation_running && is_paused) {
         ui->action_Pause->setText(tr("&Continue"));
@@ -2408,11 +2408,18 @@ void GMainWindow::OnSaveMovie() {
 }
 
 void GMainWindow::OnCaptureScreenshot() {
-    if (!emu_thread || !emu_thread->IsRunning()) [[unlikely]] {
+    if (!emu_thread) [[unlikely]] {
         return;
     }
 
-    OnPauseGame();
+    if (!emu_thread->IsRunning()
+    && (QMessageBox::question(this, tr("Game will unpause"),
+                                 tr("The game will be unpaused, and the next frame will be captured. Is this okay?"), QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)) {
+        return;
+    } else {
+        OnPauseGame();
+    }
+
     std::string path = UISettings::values.screenshot_path.GetValue();
     if (!FileUtil::IsDirectory(path)) {
         if (!FileUtil::CreateFullPath(path)) {

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -2415,7 +2415,7 @@ void GMainWindow::OnCaptureScreenshot() {
     const bool was_running = emu_thread->IsRunning();
 
     if (was_running ||
-       (QMessageBox::question(
+        (QMessageBox::question(
              this, tr("Game will unpause"),
              tr("The game will be unpaused, and the next frame will be captured. Is this okay?"),
              QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)) {
@@ -2425,9 +2425,10 @@ void GMainWindow::OnCaptureScreenshot() {
         std::string path = UISettings::values.screenshot_path.GetValue();
         if (!FileUtil::IsDirectory(path)) {
             if (!FileUtil::CreateFullPath(path)) {
-                QMessageBox::information(this, tr("Invalid Screenshot Directory"),
-                                         tr("Cannot create specified screenshot directory. Screenshot "
-                                            "path is set back to its default value."));
+                QMessageBox::information(
+                    this, tr("Invalid Screenshot Directory"),
+                    tr("Cannot create specified screenshot directory. Screenshot "
+                       "path is set back to its default value."));
                 path = FileUtil::GetUserPath(FileUtil::UserPath::UserDir);
                 path.append("screenshots/");
                 UISettings::values.screenshot_path = path;


### PR DESCRIPTION
The screenshot capture function is now working in the paused state, and using the feature will unpause the game and then capture the next frame to save as a screenshot.

A question prompt will first appear, before the game unpauses:
![CitraUnpauseMsg](https://github.com/PabloMK7/citra/assets/16110127/b902d344-21af-41f8-8b61-b31a080c7a44)