### PR TITLE
citra_qt: Add Open Log Folder option to Help menu

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -941,6 +941,10 @@ void GMainWindow::ConnectMenuEvents() {
 
     // Help
     connect_menu(ui->action_Open_Citra_Folder, &GMainWindow::OnOpenCitraFolder);
+    connect_menu(ui->action_Open_Log_Folder, []() {
+        QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
+        QDesktopServices::openUrl(QUrl::fromLocalFile(path));
+    });
     connect_menu(ui->action_FAQ, []() {
         QDesktopServices::openUrl(QUrl(QStringLiteral("https://citra-emu.org/wiki/faq/")));
     });

--- a/src/citra_qt/main.ui
+++ b/src/citra_qt/main.ui
@@ -203,6 +203,7 @@
     <addaction name="separator"/>
     <addaction name="action_Report_Compatibility"/>
     <addaction name="separator"/>
+    <addaction name="action_Open_Log_Folder"/>
     <addaction name="action_FAQ"/>
     <addaction name="action_About"/>
    </widget>
@@ -477,6 +478,14 @@
    </property>
    <property name="text">
     <string>Fullscreen</string>
+   </property>
+  </action>
+  <action name="action_Open_Log_Folder">
+   <property name="text">
+    <string>Open Log Folder</string>
+   </property>
+   <property name="toolTip">
+    <string>Opens the Citra Log folder</string>
    </property>
   </action>
   <action name="action_Open_Maintenance_Tool">


### PR DESCRIPTION
I know there's multiple ways to access the Log folder (File Explorer, File->Open Citra Folder->Logs, the Debug interface, etc.) but people on the various forums and forks still keep asking how to access the logs or that they don't know where they are that perhaps a more obvious way to access them would be helpful. And being able to point people to `Help->Open Log Folder` may make the support burden easier as it's simpler to explain.

![help-log](https://github.com/PabloMK7/citra/assets/8913195/87c92547-824f-4209-8db3-61cc0ed70e80)
