### PR TITLE
Artic Base: Fix out of bounds cache reads

### DIFF
--- a/src/common/static_lru_cache.h
+++ b/src/common/static_lru_cache.h
@@ -88,8 +88,16 @@ public:
         }
     }
 
+    void invalidate(const key_type& key) {
+        auto i = find(key);
+        if (i != m_list.cend()) {
+            m_list.erase(i);
+        }
+    }
+
     void clear() {
         m_list.clear();
+        m_array.fill(value_type{});
     }
 
 private:


### PR DESCRIPTION
Fixes reads from cache when the read doesn't match the the expected read size. This fixes a link between worlds deleting its save file.