### PR TITLE
Do not use the cache if the read would result in OOB

### DIFF
--- a/src/core/file_sys/archive_artic.cpp
+++ b/src/core/file_sys/archive_artic.cpp
@@ -383,7 +383,7 @@ ResultVal<std::size_t> ArticFileBackend::Read(u64 offset, std::size_t length, u8
     auto cache = cache_provider->ProvideCache(
         client, cache_provider->PathsToVector(archive_path, file_path), true);
 
-    if (cache != nullptr) {
+    if (cache != nullptr && (offset + static_cast<u64>(length)) < GetSize()) {
         return cache->Read(file_handle, offset, length, buffer);
     }
 


### PR DESCRIPTION
Removes the usage of the cache if the read would result in a read from OOB data. A more intelligent solution is possible, but this is a quick fix to prevent some games such as TLOZ: A Link Between Worlds to reset its save file.