### PR TITLE
Fix gcc 13+ compilation and update fmt.

### DIFF
--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -86,7 +86,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout1">
         <item>
          <widget class="QLabel" name="label_3">
           <property name="text">
@@ -100,7 +100,7 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <layout class="QHBoxLayout" name="horizontalLayout2">
         <item>
          <widget class="QCheckBox" name="toggle_console">
           <property name="text">
@@ -125,7 +125,7 @@
      <property name="title">
       <string>CPU</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QGridLayout" name="clock_speed_GLayout">
       <item row="1" column="0">
        <widget class="QWidget" name="clock_speed_widget" native="true">
         <layout class="QHBoxLayout" name="clock_speed_layout">

--- a/src/common/logging/formatter.h
+++ b/src/common/logging/formatter.h
@@ -12,9 +12,9 @@
 #if FMT_VERSION >= 80100
 template <typename T>
 struct fmt::formatter<T, std::enable_if_t<std::is_enum_v<T>, char>>
-    : formatter<std::underlying_type_t<T>> {
+    : fmt::formatter<std::underlying_type_t<T>> {
     template <typename FormatContext>
-    auto format(const T& value, FormatContext& ctx) -> decltype(ctx.out()) {
+    auto format(const T& value, FormatContext& ctx) const -> decltype(ctx.out()) {
         return fmt::formatter<std::underlying_type_t<T>>::format(
             static_cast<std::underlying_type_t<T>>(value), ctx);
     }

--- a/src/core/hle/service/cfg/cfg.cpp
+++ b/src/core/hle/service/cfg/cfg.cpp
@@ -9,7 +9,7 @@
 #include <boost/serialization/unique_ptr.hpp>
 #include <cryptopp/osrng.h>
 #include <cryptopp/sha.h>
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "common/archives.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"

--- a/src/core/hle/service/ir/extra_hid.cpp
+++ b/src/core/hle/service/ir/extra_hid.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "common/alignment.h"
 #include "common/settings.h"
 #include "core/core_timing.h"

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -8,7 +8,7 @@
 #include <boost/serialization/base_object.hpp>
 #include <boost/serialization/shared_ptr.hpp>
 #include <boost/serialization/unique_ptr.hpp>
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "common/archives.h"
 #include "common/swap.h"
 #include "core/core.h"

--- a/src/core/hle/service/soc/soc_u.cpp
+++ b/src/core/hle/service/soc/soc_u.cpp
@@ -2236,18 +2236,15 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
     }
 
     InterfaceInfo ret;
-#ifdef _WIN32
-    SOCKET sock_fd = -1;
-#else
-    int sock_fd = -1;
-#endif
+
+    SocketHolder::SOCKET sock_fd = -1;
     bool interface_found = false;
     struct sockaddr_in s_in = {.sin_family = AF_INET, .sin_port = htons(53), .sin_addr = {}};
     s_in.sin_addr.s_addr = inet_addr("8.8.8.8");
     socklen_t s_info_len = sizeof(struct sockaddr_in);
     sockaddr_in s_info;
 
-    if (static_cast<int>(sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == -1) {
+    if ((sock_fd = ::socket(AF_INET, SOCK_STREAM, 0)) == static_cast<SocketHolder::SOCKET>(-1)) {
         return std::nullopt;
     }
 
@@ -2265,7 +2262,7 @@ std::optional<SOC_U::InterfaceInfo> SOC_U::GetDefaultInterfaceInfo() {
 
 #ifdef _WIN32
     sock_fd = WSASocket(AF_INET, SOCK_DGRAM, 0, 0, 0, 0);
-    if (static_cast<int>(sock_fd) == SOCKET_ERROR) {
+    if (sock_fd == static_cast<SocketHolder::SOCKET>(SOCKET_ERROR)) {
         return std::nullopt;
     }
 

--- a/src/core/hle/service/soc/soc_u.h
+++ b/src/core/hle/service/soc/soc_u.h
@@ -25,11 +25,11 @@ namespace Service::SOC {
 struct SocketHolder {
 #ifdef _WIN32
     using SOCKET = unsigned long long;
-    SOCKET socket_fd; ///< The socket descriptor
 #else
-    int socket_fd; ///< The socket descriptor
+    using SOCKET = int;
 #endif // _WIN32
 
+    SOCKET socket_fd;     ///< The socket descriptor
     bool blocking = true; ///< Whether the socket is blocking or not.
     bool isGlobal = false;
     bool shutdown_rd = false;

--- a/src/core/movie.cpp
+++ b/src/core/movie.cpp
@@ -10,6 +10,7 @@
 #include <boost/optional.hpp>
 #include <cryptopp/hex.h>
 #include <cryptopp/osrng.h>
+#include <fmt/ranges.h>
 #include "common/archives.h"
 #include "common/bit_field.h"
 #include "common/file_util.h"

--- a/src/core/savestate.cpp
+++ b/src/core/savestate.cpp
@@ -5,7 +5,7 @@
 #include <chrono>
 #include <sstream>
 #include <cryptopp/hex.h>
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 #include "common/archives.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"

--- a/src/network/artic_base/artic_base_client.cpp
+++ b/src/network/artic_base/artic_base_client.cpp
@@ -163,7 +163,7 @@ bool Client::Connect() {
     }
 
     main_socket = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (main_socket == -1) {
+    if (main_socket == static_cast<SocketHolder>(-1)) {
         LOG_ERROR(Network, "Failed to create socket");
         SignalCommunicationError();
         return false;
@@ -249,7 +249,7 @@ bool Client::Connect() {
     std::stringstream ss_port(worker_ports.value());
     while (std::getline(ss_port, str_port, ',')) {
         int port = str_to_int(str_port);
-        if (port < 0 || port > USHRT_MAX) {
+        if (port < 0 || port > static_cast<int>(USHRT_MAX)) {
             shutdown(main_socket, SHUT_RDWR);
             closesocket(main_socket);
             LOG_ERROR(Network, "Couldn't parse server worker ports");
@@ -518,7 +518,7 @@ std::optional<ArticBaseCommon::DataPacket> Client::SendRequestPacket(
     const std::chrono::nanoseconds& read_timeout) {
     std::scoped_lock<std::mutex> l(send_mutex);
 
-    if (main_socket == -1) {
+    if (main_socket == static_cast<SocketHolder>(-1)) {
         return std::nullopt;
     }
 
@@ -586,7 +586,7 @@ Client::Handler::Handler(Client& _client, u32 _addr, u16 _port, int _id)
 
 void Client::Handler::RunLoop() {
     handler_socket = ::socket(AF_INET, SOCK_STREAM, 0);
-    if (handler_socket == -1) {
+    if (handler_socket == static_cast<SocketHolder>(-1)) {
         LOG_ERROR(Network, "Failed to create socket");
         return;
     }

--- a/src/video_core/renderer_software/sw_clipper.cpp
+++ b/src/video_core/renderer_software/sw_clipper.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cstddef>
+#include <tuple>
 #include "video_core/pica/regs_texturing.h"
 #include "video_core/renderer_software/sw_clipper.h"
 

--- a/src/video_core/renderer_vulkan/vk_instance.cpp
+++ b/src/video_core/renderer_vulkan/vk_instance.cpp
@@ -4,7 +4,7 @@
 
 #include <span>
 #include <boost/container/static_vector.hpp>
-#include <fmt/format.h>
+#include <fmt/ranges.h>
 
 #include "common/assert.h"
 #include "common/settings.h"

--- a/src/video_core/renderer_vulkan/vk_shader_util.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_util.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <memory>
 #include <SPIRV/GlslangToSpv.h>
 #include <glslang/Include/ResourceLimits.h>
 #include <glslang/Public/ShaderLang.h>


### PR DESCRIPTION
Fix compilation errors, and update fmt for the same reason.

An example of a compilation error:

`error: comparison of integer expressions of different signedness: 'SocketHolder' {aka 'long long unsigned int'} and 'int' [-Werror=sign-compare]`

By updating fmt, it will fix:
  `integer_sequence<bool, (Is == Is)...>  [-Werror=tautological-compare]`
The updating is helpful and needed.
Fmt has gone through two public versions since its last update and has fixed many bugs, including new compiler optimizations.
But neither of these two public versions can fix the errors encountered above.
We need to switch to a working version. Very helpful. The selected version works well.
Synchronously updating local code.

configure_debug.ui: there are two variables named repeatedly here, which raises a warning.

