### PR TITLE
Fix HTTP RequestState values (fixes Pretendo Network support with HLE http)

### DIFF
--- a/src/core/hle/service/http/http_c.cpp
+++ b/src/core/hle/service/http/http_c.cpp
@@ -381,10 +381,10 @@ void Context::MakeRequestNonSSL(httplib::Request& request, const URLInfo& url_in
 
     if (!client->send(request, response, error)) {
         LOG_ERROR(Service_HTTP, "Request failed: {}: {}", error, httplib::to_string(error));
-        state = RequestState::TimedOut;
+        state = RequestState::Completed;
     } else {
         LOG_DEBUG(Service_HTTP, "Request successful");
-        state = RequestState::ReadyToDownloadContent;
+        state = RequestState::ReceivingBody;
     }
 }
 
@@ -439,10 +439,10 @@ void Context::MakeRequestSSL(httplib::Request& request, const URLInfo& url_info,
 
     if (!client->send(request, response, error)) {
         LOG_ERROR(Service_HTTP, "Request failed: {}: {}", error, httplib::to_string(error));
-        state = RequestState::TimedOut;
+        state = RequestState::Completed;
     } else {
         LOG_DEBUG(Service_HTTP, "Request successful");
-        state = RequestState::ReadyToDownloadContent;
+        state = RequestState::ReceivingBody;
     }
 }
 
@@ -696,6 +696,7 @@ void HTTP_C::ReceiveDataImpl(Kernel::HLERequestContext& ctx, bool timeout) {
                                               http_context.current_copied_data,
                                           0, remaining_data);
                 http_context.current_copied_data += remaining_data;
+                http_context.state = RequestState::Completed;
                 rb.Push(ResultSuccess);
             } else {
                 async_data->buffer->Write(http_context.response.body.data() +

--- a/src/core/hle/service/http/http_c.h
+++ b/src/core/hle/service/http/http_c.h
@@ -48,12 +48,16 @@ enum class RequestMethod : u8 {
 constexpr u32 TotalRequestMethods = 8;
 
 enum class RequestState : u8 {
-    NotStarted = 0x1,             // Request has not started yet.
-    ConnectingToServer = 0x5,     // Request in progress, connecting to server.
-    SendingRequest = 0x6,         // Request in progress, sending HTTP request.
-    ReceivingResponse = 0x7,      // Request in progress, receiving HTTP response.
-    ReadyToDownloadContent = 0x8, // Ready to download the content.
-    TimedOut = 0xA,               // Request timed out?
+    NotStarted = 0x1,         // Request has not started yet.
+    ConnectingToServer = 0x5, // Request in progress, connecting to server.
+    SendingRequest = 0x6,     // Request in progress, sending HTTP request.
+    ReceivingResponse = 0x7,  // Request in progress, receiving HTTP response and headers.
+    ReceivingBody = 0x8,      // Request in progress, receiving HTTP body. The HTTP module may
+                              // get stuck in this state if the internal receive buffer gets full.
+                              // Once the user calls ReceiveData it will get unstuck.
+    Received = 0x9,  // Request is finished and all data has been received. HTTP transitions
+                     // to the Completed state shortly afterwards after some cleanup.
+    Completed = 0xA, // Request is completed.
 };
 
 enum class PostDataEncoding : u8 {

--- a/src/core/hle/service/http/http_c.h
+++ b/src/core/hle/service/http/http_c.h
@@ -48,16 +48,29 @@ enum class RequestMethod : u8 {
 constexpr u32 TotalRequestMethods = 8;
 
 enum class RequestState : u8 {
-    NotStarted = 0x1,         // Request has not started yet.
-    ConnectingToServer = 0x5, // Request in progress, connecting to server.
-    SendingRequest = 0x6,     // Request in progress, sending HTTP request.
-    ReceivingResponse = 0x7,  // Request in progress, receiving HTTP response and headers.
-    ReceivingBody = 0x8,      // Request in progress, receiving HTTP body. The HTTP module may
-                              // get stuck in this state if the internal receive buffer gets full.
-                              // Once the user calls ReceiveData it will get unstuck.
-    Received = 0x9,  // Request is finished and all data has been received. HTTP transitions
-                     // to the Completed state shortly afterwards after some cleanup.
-    Completed = 0xA, // Request is completed.
+    /// Request has not started yet.
+    NotStarted = 0x1,
+
+    /// Request in progress, connecting to server.
+    ConnectingToServer = 0x5,
+
+    /// Request in progress, sending HTTP request.
+    SendingRequest = 0x6,
+
+    // Request in progress, receiving HTTP response and headers.
+    ReceivingResponse = 0x7,
+
+    /// Request in progress, receiving HTTP body. The HTTP module may
+    /// get stuck in this state if the internal receive buffer gets full.
+    /// Once the user calls ReceiveData it will get unstuck.
+    ReceivingBody = 0x8,
+
+    /// Request is finished and all data has been received. HTTP transitions
+    /// to the Completed state shortly afterwards after some cleanup.
+    Received = 0x9,
+
+    /// Request is completed.
+    Completed = 0xA,
 };
 
 enum class PostDataEncoding : u8 {


### PR DESCRIPTION
Fixed the `RequestState` enum having the wrong valeus/meanings/documentation. Updated the HTTP HLE methods to use the values properly.

This change fixes Pretendo Network not working properly while using HLE HTTP. Using LLE HTTP is still broken due to a bug in Pretendo Network HTTP patch.