### PR TITLE
Y2R: Set is_busy_conversion to false when stopping conversion

### DIFF
--- a/src/core/hle/service/cam/y2r_u.cpp
+++ b/src/core/hle/service/cam/y2r_u.cpp
@@ -544,6 +544,7 @@ void Y2R_U::StopConversion(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
 
     if (is_busy_conversion) {
+        is_busy_conversion = false;
         system.CoreTiming().RemoveEvent(completion_signal_event);
     }
 


### PR DESCRIPTION
With the current code, is_busy_conversion would never be set to false if a game calls StopConversion mid-conversion. Which also means that IsBusyConversion would forever return true.
