### PR TITLE
Renderer: Implement setting to delay the game render thread

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -40,7 +40,8 @@ enum class IntSetting(
     VSYNC("use_vsync_new", Settings.SECTION_RENDERER, 1),
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
-    USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1);
+    USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1),
+    DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0);
 
     override var int: Int = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -729,6 +729,18 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     IntSetting.TEXTURE_FILTER.defaultValue
                 )
             )
+            add(
+                SliderSetting(
+                    IntSetting.DELAY_RENDER_THREAD_US,
+                    R.string.delay_render_thread,
+                    R.string.delay_render_thread_description,
+                    0,
+                    16000,
+                    " μs",
+                    IntSetting.DELAY_RENDER_THREAD_US.key,
+                    IntSetting.DELAY_RENDER_THREAD_US.defaultValue.toFloat()
+                )
+            )
 
             add(HeaderSetting(R.string.stereoscopy))
             add(

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -169,6 +169,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.bg_red);
     ReadSetting("Renderer", Settings::values.bg_green);
     ReadSetting("Renderer", Settings::values.bg_blue);
+    ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
 
     // Layout
     Settings::values.layout_option = static_cast<Settings::LayoutOption>(sdl2_config->GetInteger(

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -175,6 +175,10 @@ anaglyph_shader_name =
 # 0: Nearest, 1 (default): Linear
 filter_mode =
 
+# Delays the game render thread by the specified amount of microseconds
+# Set to 0 for no delay, only useful in dynamic-fps games to simulate GPU delay.
+delay_game_render_thread_us =
+
 [Layout]
 # Layout for the screen inside the render window.
 # 0 (default): Default Top Bottom Screen, 1: Single Screen Only, 2: Large Screen Small Screen, 3: Side by Side

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -663,5 +663,7 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="artic_base_connect">Conectar con Artic Base</string>
     <string name="artic_base_connect_description">Conectar con una consola real que esté ejecutando un servidor Artic Base</string>
     <string name="artic_base_enter_address">Introduce la dirección del servidor Artic Base</string>
+    <string name="delay_render_thread">Retrasa el hilo de dibujado del juego</string>
+    <string name="delay_render_thread_description">Retrasa el hilo de dibujado del juego cuando envía datos a la GPU. Ayuda con problemas de rendimiento en los (muy pocos) juegos de fps dinámicos.</string>
 
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -689,5 +689,7 @@
     <string name="artic_base_connect_description">Connect to a real console that is running an Artic Base server</string>
     <string name="artic_base_connect">Connect to Artic Base</string>
     <string name="artic_base_enter_address">Enter Artic Base server address</string>
+    <string name="delay_render_thread">Delay game render thread</string>
+    <string name="delay_render_thread_description">Delay the game render thread when it submits data to the GPU. Helps with performance issues in the (very few) dynamic-fps games.</string>
 
 </resources>

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -147,6 +147,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_vsync_new);
     ReadSetting("Renderer", Settings::values.texture_filter);
     ReadSetting("Renderer", Settings::values.texture_sampling);
+    ReadSetting("Renderer", Settings::values.delay_game_render_thread_us);
 
     ReadSetting("Renderer", Settings::values.mono_render_option);
     ReadSetting("Renderer", Settings::values.render_3d);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -667,6 +667,8 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.texture_filter);
     ReadGlobalSetting(Settings::values.texture_sampling);
 
+    ReadGlobalSetting(Settings::values.delay_game_render_thread_us);
+
     if (global) {
         ReadBasicSetting(Settings::values.use_shader_jit);
     }
@@ -1167,6 +1169,8 @@ void Config::SaveRendererValues() {
 
     WriteGlobalSetting(Settings::values.texture_filter);
     WriteGlobalSetting(Settings::values.texture_sampling);
+
+    WriteGlobalSetting(Settings::values.delay_game_render_thread_us);
 
     if (global) {
         WriteSetting(QStringLiteral("use_shader_jit"), Settings::values.use_shader_jit.GetValue(),

--- a/src/citra_qt/configuration/configure_graphics.ui
+++ b/src/citra_qt/configuration/configure_graphics.ui
@@ -307,6 +307,83 @@
         </property>
        </widget>
       </item>
+      <item>
+        <widget class="QWidget" name="delay_render_layout" native="true">
+          <layout class="QHBoxLayout" name="delay_render_layout_inner">
+            <property name="leftMargin">
+              <number>0</number>
+            </property>
+            <property name="topMargin">
+              <number>0</number>
+            </property>
+            <property name="rightMargin">
+              <number>0</number>
+            </property>
+            <property name="bottomMargin">
+              <number>0</number>
+            </property>
+            <item>
+              <widget class="QComboBox" name="delay_render_combo">
+                <item>
+                  <property name="text">
+                    <string>Use global</string>
+                  </property>
+                </item>
+                <item>
+                  <property name="text">
+                    <string>Use per-game</string>
+                  </property>
+                </item>
+              </widget>
+            </item>
+            <item>
+              <widget class="QLabel" name="label_delay_render">
+                <property name="text">
+                  <string>Delay game render thread:</string>
+                </property>
+                <property name="toolTip">
+                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Delays the emulated game render thread the specified amount of milliseconds every time it submits render commands to the GPU.&lt;/p&gt;&lt;p&gt;Adjust this feature in the (very few) dynamic-fps games to fix performance issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QSlider" name="delay_render_slider">
+                <property name="minimum">
+                  <number>0</number>
+                </property>
+                <property name="maximum">
+                  <number>16000</number>
+                </property>
+                <property name="singleStep">
+                  <number>100</number>
+                </property>
+                <property name="pageStep">
+                  <number>250</number>
+                </property>
+                <property name="value">
+                  <number>0</number>
+                </property>
+                <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="tickPosition">
+                  <enum>QSlider::TicksBelow</enum>
+                </property>
+              </widget>
+            </item>
+            <item>
+              <widget class="QLabel" name="delay_render_display_label">
+                <property name="text">
+                  <string/>
+                </property>
+                <property name="alignment">
+                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+              </widget>
+            </item>
+          </layout>
+        </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -100,6 +100,7 @@ void LogSettings() {
     log_setting("Renderer_TextureFilter", GetTextureFilterName(values.texture_filter.GetValue()));
     log_setting("Renderer_TextureSampling",
                 GetTextureSamplingName(values.texture_sampling.GetValue()));
+    log_setting("Renderer_DelayGameRenderThreasUs", values.delay_game_render_thread_us.GetValue());
     log_setting("Stereoscopy_Render3d", values.render_3d.GetValue());
     log_setting("Stereoscopy_Factor3d", values.factor_3d.GetValue());
     log_setting("Stereoscopy_MonoRenderOption", values.mono_render_option.GetValue());
@@ -192,6 +193,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.frame_limit.SetGlobal(true);
     values.texture_filter.SetGlobal(true);
     values.texture_sampling.SetGlobal(true);
+    values.delay_game_render_thread_us.SetGlobal(true);
     values.layout_option.SetGlobal(true);
     values.swap_screen.SetGlobal(true);
     values.upright_screen.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -479,6 +479,8 @@ struct Values {
     SwitchableSetting<TextureFilter> texture_filter{TextureFilter::None, "texture_filter"};
     SwitchableSetting<TextureSampling> texture_sampling{TextureSampling::GameControlled,
                                                         "texture_sampling"};
+    SwitchableSetting<u16, true> delay_game_render_thread_us{0, 0, 16000,
+                                                             "delay_game_render_thread_us"};
 
     SwitchableSetting<LayoutOption> layout_option{LayoutOption::Default, "layout_option"};
     SwitchableSetting<bool> swap_screen{false, "swap_screen"};


### PR DESCRIPTION
Read this for more details: https://www.reddit.com/r/Citra/comments/1e1v4e1/fixing_luigis_mansion_2_performance_issues_once/

Adds a setting that puts the game render thread to sleep a certain amount of milliseconds. This helps with performance issues in dynamic-fps games, such as Luigi's Mansion 2.

UI changes:
![citra-qt_89VjC2u4kf](https://github.com/user-attachments/assets/f94fbd05-0165-4b16-b0f9-84f65b28ba6a)
