### PR TITLE
android: implement device rotation options

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/activities/EmulationActivity.kt
@@ -35,6 +35,8 @@ import org.citra.citra_emu.display.ScreenAdjustmentUtil
 import org.citra.citra_emu.features.hotkeys.HotkeyUtility
 import org.citra.citra_emu.features.settings.model.SettingsViewModel
 import org.citra.citra_emu.features.settings.model.view.InputBindingSetting
+import org.citra.citra_emu.features.settings.model.IntSetting
+import org.citra.citra_emu.features.settings.model.Settings
 import org.citra.citra_emu.fragments.MessageDialogFragment
 import org.citra.citra_emu.utils.ControllerMappingHelper
 import org.citra.citra_emu.utils.FileBrowserHelper
@@ -60,7 +62,10 @@ class EmulationActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         ThemeUtil.setTheme(this)
 
-        settingsViewModel.settings.loadSettings()
+        isActivityRecreated = savedInstanceState != null
+        if (!isActivityRecreated) {
+            settingsViewModel.settings.loadSettings()
+        }
 
         super.onCreate(savedInstanceState)
 
@@ -73,8 +78,6 @@ class EmulationActivity : AppCompatActivity() {
             supportFragmentManager.findFragmentById(R.id.fragment_container) as NavHostFragment
         val navController = navHostFragment.navController
         navController.setGraph(R.navigation.emulation_navigation, intent.extras)
-
-        isActivityRecreated = savedInstanceState != null
 
         // Set these options now so that the SurfaceView the game renders into is the right size.
         enableFullscreenImmersive()
@@ -175,6 +178,11 @@ class EmulationActivity : AppCompatActivity() {
             controller.systemBarsBehavior =
                 WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
         }
+
+
+        val orientation = settingsViewModel.settings.getSection(Settings.SECTION_RENDERER)
+            ?.getSetting(IntSetting.DEVICE_ORIENTATION.key) as IntSetting
+        this.requestedOrientation = orientation.int
     }
 
     // Gets button presses

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -4,6 +4,8 @@
 
 package org.citra.citra_emu.features.settings.model
 
+import android.content.pm.ActivityInfo
+
 enum class IntSetting(
     override val key: String,
     override val section: String,
@@ -41,7 +43,8 @@ enum class IntSetting(
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1),
-    DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0);
+    DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0),
+    DEVICE_ORIENTATION("default_device_orientation", Settings.SECTION_RENDERER, ActivityInfo.SCREEN_ORIENTATION_USER);
 
     override var int: Int = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -173,6 +173,20 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     private fun addGeneralSettings(sl: ArrayList<SettingsItem>) {
         settingsActivity.setToolbarTitle(settingsActivity.getString(R.string.preferences_general))
         sl.apply {
+            add(HeaderSetting(R.string.graphics_ui))
+            add(
+                SingleChoiceSetting(
+                    IntSetting.DEVICE_ORIENTATION,
+                    R.string.device_orientation_title,
+                    R.string.device_orientation_description,
+                    R.array.deviceOrientationEntries,
+                    R.array.deviceOrientationValues,
+                    IntSetting.DEVICE_ORIENTATION.key,
+                    IntSetting.DEVICE_ORIENTATION.defaultValue,
+                )
+            )
+
+            add(HeaderSetting(R.string.emulator_speed))
             add(
                 SwitchSetting(
                     IntSetting.USE_FRAME_LIMIT,
@@ -649,19 +663,6 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     private fun addGraphicsSettings(sl: ArrayList<SettingsItem>) {
         settingsActivity.setToolbarTitle(settingsActivity.getString(R.string.preferences_graphics))
         sl.apply {
-            add(HeaderSetting(R.string.graphics_ui))
-            add(
-                SingleChoiceSetting(
-                    IntSetting.DEVICE_ORIENTATION,
-                    R.string.device_orientation_title,
-                    R.string.device_orientation_description,
-                    R.array.deviceOrientationEntries,
-                    R.array.deviceOrientationValues,
-                    IntSetting.DEVICE_ORIENTATION.key,
-                    IntSetting.DEVICE_ORIENTATION.defaultValue,
-                )
-            )
-
             add(HeaderSetting(R.string.renderer))
             add(
                 SingleChoiceSetting(

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -649,6 +649,19 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
     private fun addGraphicsSettings(sl: ArrayList<SettingsItem>) {
         settingsActivity.setToolbarTitle(settingsActivity.getString(R.string.preferences_graphics))
         sl.apply {
+            add(HeaderSetting(R.string.graphics_ui))
+            add(
+                SingleChoiceSetting(
+                    IntSetting.DEVICE_ORIENTATION,
+                    R.string.device_orientation_title,
+                    R.string.device_orientation_description,
+                    R.array.deviceOrientationEntries,
+                    R.array.deviceOrientationValues,
+                    IntSetting.DEVICE_ORIENTATION.key,
+                    IntSetting.DEVICE_ORIENTATION.defaultValue,
+                )
+            )
+
             add(HeaderSetting(R.string.renderer))
             add(
                 SingleChoiceSetting(

--- a/src/android/app/src/main/res/values/arrays.xml
+++ b/src/android/app/src/main/res/values/arrays.xml
@@ -191,6 +191,21 @@
         <item>2</item>
     </integer-array>
 
+    <string-array name="deviceOrientationEntries">
+        <item>@string/device_orientation_system</item>
+        <item>@string/device_orientation_landscape</item>
+        <item>@string/device_orientation_portrait</item>
+        <item>@string/device_orientation_auto</item>
+    </string-array>
+
+    <!-- See: https://developer.android.com/reference/android/content/pm/ActivityInfo#SCREEN_ORIENTATION_SENSOR-->
+    <integer-array name="deviceOrientationValues">
+        <item>2</item>
+        <item>6</item>
+        <item>7</item>
+        <item>4</item>
+    </integer-array>
+
     <string-array name="systemFileRegions">
         <item>@string/system_region_jpn</item>
         <item>@string/system_region_usa</item>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -468,7 +468,7 @@
 
     <!-- Device Orientation -->
     <string name="device_orientation_title">Screen Orientation</string>
-    <string name="device_orientation_description">How should Lime3DS display your games?</string>
+    <string name="device_orientation_description">How should your games be displayed?</string>
     <string name="device_orientation_system">Follow System Setting</string>
     <string name="device_orientation_landscape">Landscape</string>
     <string name="device_orientation_portrait">Portrait</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
 
     <!-- Graphics settings strings -->
     <string name="graphics_ui">UI</string>
+    <string name="emulator_speed">Speed</string>
     <string name="renderer">Renderer</string>
     <string name="graphics_api">Graphics API</string>
     <string name="spirv_shader_gen">Enable SPIR-V shader generation</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="image_flip">Flip</string>
 
     <!-- Graphics settings strings -->
+    <string name="graphics_ui">UI</string>
     <string name="renderer">Renderer</string>
     <string name="graphics_api">Graphics API</string>
     <string name="spirv_shader_gen">Enable SPIR-V shader generation</string>
@@ -464,6 +465,14 @@
     <!-- Black backgrounds theme -->
     <string name="use_black_backgrounds">Black Backgrounds</string>
     <string name="use_black_backgrounds_description">When using the dark theme, apply black backgrounds.</string>
+
+    <!-- Device Orientation -->
+    <string name="device_orientation_title">Screen Orientation</string>
+    <string name="device_orientation_description">How should Lime3DS display your games?</string>
+    <string name="device_orientation_system">Follow System Setting</string>
+    <string name="device_orientation_landscape">Landscape</string>
+    <string name="device_orientation_portrait">Portrait</string>
+    <string name="device_orientation_auto">Automatic</string>
 
     <!-- Clock types -->
     <string name="device_clock">Device Clock</string>


### PR DESCRIPTION
This adds the ability to change the screen-orientation for the emulator in the settings. Live switching is possible.


This PR was also opened in the Lime3DS repository. All code was written by me.