### PR TITLE
Workaround a performance bug in older Mali GPUs

### DIFF
--- a/src/video_core/renderer_opengl/gl_driver.cpp
+++ b/src/video_core/renderer_opengl/gl_driver.cpp
@@ -199,6 +199,15 @@ void Driver::FindBugs() {
     if (vendor == Vendor::Intel && !is_linux) {
         bugs |= DriverBug::BrokenClearTexture;
     }
+
+    if (vendor == Vendor::ARM && gpu_model.find("Mali") != gpu_model.npos) {
+        constexpr GLint MIN_TEXTURE_BUFFER_SIZE = static_cast<GLint>((1 << 16));
+        GLint max_texel_buffer_size;
+        glGetIntegerv(GL_MAX_TEXTURE_BUFFER_SIZE, &max_texel_buffer_size);
+        if (max_texel_buffer_size == MIN_TEXTURE_BUFFER_SIZE) {
+            bugs |= DriverBug::SlowTextureBufferWithBigSize;
+        }
+    }
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_driver.h
+++ b/src/video_core/renderer_opengl/gl_driver.h
@@ -36,6 +36,9 @@ enum class DriverBug {
     BrokenTextureView = 1 << 2,
     // On Haswell and Broadwell Intel drivers glClearTexSubImage produces a black screen
     BrokenClearTexture = 1 << 3,
+    // On some Mali GPUs, the texture buffer size is small and has reduced performance
+    // if the buffer is close to the maximum texture size
+    SlowTextureBufferWithBigSize = 1 << 4,
 };
 
 /**

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -145,7 +145,6 @@ private:
     OGLVertexArray hw_vao; // VAO for hardware shader / accelerate draw
     std::array<bool, 16> hw_vao_enabled_attributes{};
 
-    GLsizeiptr texture_buffer_size;
     OGLStreamBuffer vertex_buffer;
     OGLStreamBuffer uniform_buffer;
     OGLStreamBuffer index_buffer;


### PR DESCRIPTION
Reduces the texture buffer size in older Mali GPUs which have performance issues on buffers close to the max size.