### PR TITLE
Artic Base: Add Artic Controller support

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -41,7 +41,8 @@ enum class IntSetting(
     DEBUG_RENDERER("renderer_debug", Settings.SECTION_DEBUG, 0),
     TEXTURE_FILTER("texture_filter", Settings.SECTION_RENDERER, 0),
     USE_FRAME_LIMIT("use_frame_limit", Settings.SECTION_RENDERER, 1),
-    DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0);
+    DELAY_RENDER_THREAD_US("delay_game_render_thread_us", Settings.SECTION_RENDERER, 0),
+    USE_ARTIC_BASE_CONTROLLER("use_artic_base_controller", Settings.SECTION_CONTROLS, 0);
 
     override var int: Int = defaultValue
 
@@ -69,7 +70,8 @@ enum class IntSetting(
             DEBUG_RENDERER,
             CPU_JIT,
             ASYNC_CUSTOM_LOADING,
-            AUDIO_INPUT_TYPE
+            AUDIO_INPUT_TYPE,
+            USE_ARTIC_BASE_CONTROLLER
         )
 
         fun from(key: String): IntSetting? = IntSetting.values().firstOrNull { it.key == key }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -626,6 +626,16 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.hotkeyTitles[i]))
             }
+            add(HeaderSetting(R.string.miscellaneous))
+            add(
+                SwitchSetting(
+                    IntSetting.USE_ARTIC_BASE_CONTROLLER,
+                    R.string.use_artic_base_controller,
+                    R.string.use_artic_base_controller_desc,
+                    IntSetting.USE_ARTIC_BASE_CONTROLLER.key,
+                    IntSetting.USE_ARTIC_BASE_CONTROLLER.defaultValue
+                )
+            )
         }
     }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -128,6 +128,8 @@ void Config::ReadValues() {
         static_cast<u16>(sdl2_config->GetInteger("Controls", "udp_input_port",
                                                  InputCommon::CemuhookUDP::DEFAULT_PORT));
 
+    ReadSetting("Controls", Settings::values.use_artic_base_controller);
+
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
     ReadSetting("Core", Settings::values.cpu_clock_percentage);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -86,6 +86,9 @@ udp_input_port=
 # The pad to request data on. Should be between 0 (Pad 1) and 3 (Pad 4). (Default 0)
 udp_pad_index=
 
+# Use Artic Controller when connected to Artic Base Server. (Default 0)
+use_artic_base_controller=
+
 [Core]
 # Whether to use the Just-In-Time (JIT) compiler for CPU emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)

--- a/src/android/app/src/main/res/values-es/strings.xml
+++ b/src/android/app/src/main/res/values-es/strings.xml
@@ -665,5 +665,8 @@ Se esperan fallos gráficos temporales cuando ésta esté activado.</string>
     <string name="artic_base_enter_address">Introduce la dirección del servidor Artic Base</string>
     <string name="delay_render_thread">Retrasa el hilo de dibujado del juego</string>
     <string name="delay_render_thread_description">Retrasa el hilo de dibujado del juego cuando envía datos a la GPU. Ayuda con problemas de rendimiento en los (muy pocos) juegos de fps dinámicos.</string>
+    <string name="miscellaneous">Misceláneo</string>
+    <string name="use_artic_base_controller">Usar Artic Controller cuando se está conectado a Artic Base Server</string>
+    <string name="use_artic_base_controller_desc">Usa los controles proporcionados por Artic Base Server cuando esté conectado a él en lugar del dispositivo de entrada configurado.</string>
 
 </resources>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -700,5 +700,8 @@
     <string name="quicksave_saving">Saving…</string>
     <string name="quickload_loading">Loading…</string>
     <string name="quickload_not_found">No Quicksave available.</string>
+    <string name="miscellaneous">Miscellaneous</string>
+    <string name="use_artic_base_controller">Use Artic Controller when connected to Artic Base Server</string>
+    <string name="use_artic_base_controller_desc">Use the controls provided by Artic Base Server when connected to it instead of the configured input device.</string>
 
 </resources>

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -327,6 +327,8 @@ void Config::ReadCameraValues() {
 void Config::ReadControlValues() {
     qt_config->beginGroup(QStringLiteral("Controls"));
 
+    ReadBasicSetting(Settings::values.use_artic_base_controller);
+
     int num_touch_from_button_maps =
         qt_config->beginReadArray(QStringLiteral("touch_from_button_maps"));
 
@@ -923,6 +925,8 @@ void Config::SaveCameraValues() {
 
 void Config::SaveControlValues() {
     qt_config->beginGroup(QStringLiteral("Controls"));
+
+    WriteBasicSetting(Settings::values.use_artic_base_controller);
 
     WriteSetting(QStringLiteral("profile"), Settings::values.current_input_profile_index, 0);
     qt_config->beginWriteArray(QStringLiteral("profiles"));

--- a/src/citra_qt/configuration/configure_dialog.cpp
+++ b/src/citra_qt/configuration/configure_dialog.cpp
@@ -29,7 +29,7 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_, Cor
       system{system_}, is_powered_on{system.IsPoweredOn()},
       general_tab{std::make_unique<ConfigureGeneral>(this)},
       system_tab{std::make_unique<ConfigureSystem>(system, this)},
-      input_tab{std::make_unique<ConfigureInput>(this)},
+      input_tab{std::make_unique<ConfigureInput>(system, this)},
       hotkeys_tab{std::make_unique<ConfigureHotkeys>(this)},
       graphics_tab{
           std::make_unique<ConfigureGraphics>(gl_renderer, physical_devices, is_powered_on, this)},

--- a/src/citra_qt/configuration/configure_input.cpp
+++ b/src/citra_qt/configuration/configure_input.cpp
@@ -16,6 +16,7 @@
 #include "citra_qt/configuration/configure_input.h"
 #include "citra_qt/configuration/configure_motion_touch.h"
 #include "common/param_package.h"
+#include "core/core.h"
 #include "ui_configure_input.h"
 
 const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
@@ -145,8 +146,8 @@ static QString AnalogToText(const Common::ParamPackage& param, const std::string
     return QObject::tr("[unknown]");
 }
 
-ConfigureInput::ConfigureInput(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()),
+ConfigureInput::ConfigureInput(Core::System& _system, QWidget* parent)
+    : QWidget(parent), system(_system), ui(std::make_unique<Ui::ConfigureInput>()),
       timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()) {
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);
@@ -400,6 +401,9 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 ConfigureInput::~ConfigureInput() = default;
 
 void ConfigureInput::ApplyConfiguration() {
+
+    Settings::values.use_artic_base_controller = ui->use_artic_controller->isChecked();
+
     std::transform(buttons_param.begin(), buttons_param.end(),
                    Settings::values.current_input_profile.buttons.begin(),
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
@@ -444,6 +448,10 @@ QList<QKeySequence> ConfigureInput::GetUsedKeyboardKeys() {
 }
 
 void ConfigureInput::LoadConfiguration() {
+
+    ui->use_artic_controller->setChecked(Settings::values.use_artic_base_controller.GetValue());
+    ui->use_artic_controller->setEnabled(!system.IsPoweredOn());
+
     std::transform(Settings::values.current_input_profile.buttons.begin(),
                    Settings::values.current_input_profile.buttons.end(), buttons_param.begin(),
                    [](const std::string& str) { return Common::ParamPackage(str); });

--- a/src/citra_qt/configuration/configure_input.h
+++ b/src/citra_qt/configuration/configure_input.h
@@ -30,7 +30,7 @@ class ConfigureInput : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureInput(QWidget* parent = nullptr);
+    explicit ConfigureInput(Core::System& system, QWidget* parent = nullptr);
     ~ConfigureInput() override;
 
     /// Save all button configurations to settings file
@@ -50,6 +50,7 @@ signals:
     void InputKeysChanged(QList<QKeySequence> new_key_list);
 
 private:
+    Core::System& system;
     std::unique_ptr<Ui::ConfigureInput> ui;
 
     std::unique_ptr<QTimer> timeout_timer;

--- a/src/citra_qt/configuration/configure_input.ui
+++ b/src/citra_qt/configuration/configure_input.ui
@@ -841,6 +841,13 @@
        </item>
       </layout>
      </item>
+     <item>
+       <widget class="QCheckBox" name="use_artic_controller">
+         <property name="text">
+           <string>Use Artic Controller when connected to Artic Base Server</string>
+         </property>
+       </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -83,6 +83,7 @@ void LogSettings() {
     LOG_INFO(Config, "Citra Configuration:");
     log_setting("Core_UseCpuJit", values.use_cpu_jit.GetValue());
     log_setting("Core_CPUClockPercentage", values.cpu_clock_percentage.GetValue());
+    log_setting("Controller_UseArticController", values.use_artic_base_controller.GetValue());
     log_setting("Renderer_UseGLES", values.use_gles.GetValue());
     log_setting("Renderer_GraphicsAPI", GetGraphicsAPIName(values.graphics_api.GetValue()));
     log_setting("Renderer_AsyncShaders", values.async_shader_compilation.GetValue());

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -425,6 +425,7 @@ struct Values {
     int current_input_profile_index;          ///< The current input profile index
     std::vector<InputProfile> input_profiles; ///< The list of input profiles
     std::vector<TouchFromButtonMap> touch_from_button_maps;
+    Setting<bool> use_artic_base_controller{false, "use_artic_base_controller"};
 
     SwitchableSetting<bool> enable_gamemode{true, "enable_gamemode"};
 

--- a/src/core/hle/service/ir/extra_hid.h
+++ b/src/core/hle/service/ir/extra_hid.h
@@ -19,6 +19,10 @@ class Timing;
 class Movie;
 } // namespace Core
 
+namespace Service::HID {
+class ArticBaseController;
+};
+
 namespace Service::IR {
 
 struct ExtraHIDResponse {
@@ -54,6 +58,10 @@ public:
     /// Requests input devices reload from current settings. Called when the input settings change.
     void RequestInputDevicesReload();
 
+    void UseArticController(const std::shared_ptr<Service::HID::ArticBaseController>& ac) {
+        artic_controller = ac;
+    }
+
 private:
     void SendHIDStatus();
     void HandleConfigureHIDPollingRequest(std::span<const u8> request);
@@ -69,6 +77,8 @@ private:
     std::unique_ptr<Input::ButtonDevice> zr;
     std::unique_ptr<Input::AnalogDevice> c_stick;
     std::atomic<bool> is_device_reload_pending;
+
+    std::shared_ptr<Service::HID::ArticBaseController> artic_controller = nullptr;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int) {

--- a/src/core/hle/service/ir/ir_rst.cpp
+++ b/src/core/hle/service/ir/ir_rst.cpp
@@ -72,25 +72,41 @@ void IR_RST::UpdateCallback(std::uintptr_t user_data, s64 cycles_late) {
     if (is_device_reload_pending.exchange(false))
         LoadInputDevices();
 
+    constexpr u32 VALID_EXTRAHID_KEYS = 0xF00C000;
+
     PadState state;
-    state.zl.Assign(zl_button->GetStatus());
-    state.zr.Assign(zr_button->GetStatus());
+    s16 c_stick_x, c_stick_y;
 
-    // Get current c-stick position and update c-stick direction
-    float c_stick_x_f, c_stick_y_f;
-    std::tie(c_stick_x_f, c_stick_y_f) = c_stick->GetStatus();
-    constexpr int MAX_CSTICK_RADIUS = 0x9C; // Max value for a c-stick radius
-    s16 c_stick_x = static_cast<s16>(c_stick_x_f * MAX_CSTICK_RADIUS);
-    s16 c_stick_y = static_cast<s16>(c_stick_y_f * MAX_CSTICK_RADIUS);
+    if (artic_controller.get() && artic_controller->IsReady()) {
+        Service::HID::ArticBaseController::ControllerData data =
+            artic_controller->GetControllerData();
 
-    system.Movie().HandleIrRst(state, c_stick_x, c_stick_y);
+        state.hex = data.pad & VALID_EXTRAHID_KEYS;
 
-    if (!raw_c_stick) {
-        const HID::DirectionState direction = HID::GetStickDirectionState(c_stick_x, c_stick_y);
-        state.c_stick_up.Assign(direction.up);
-        state.c_stick_down.Assign(direction.down);
-        state.c_stick_left.Assign(direction.left);
-        state.c_stick_right.Assign(direction.right);
+        c_stick_x = data.c_stick_x;
+        c_stick_y = data.c_stick_y;
+
+        system.Movie().HandleIrRst(state, c_stick_x, c_stick_y);
+    } else {
+        state.zl.Assign(zl_button->GetStatus());
+        state.zr.Assign(zr_button->GetStatus());
+
+        // Get current c-stick position and update c-stick direction
+        float c_stick_x_f, c_stick_y_f;
+        std::tie(c_stick_x_f, c_stick_y_f) = c_stick->GetStatus();
+        constexpr int MAX_CSTICK_RADIUS = 0x9C; // Max value for a c-stick radius
+        c_stick_x = static_cast<s16>(c_stick_x_f * MAX_CSTICK_RADIUS);
+        c_stick_y = static_cast<s16>(c_stick_y_f * MAX_CSTICK_RADIUS);
+
+        system.Movie().HandleIrRst(state, c_stick_x, c_stick_y);
+
+        if (!raw_c_stick) {
+            const HID::DirectionState direction = HID::GetStickDirectionState(c_stick_x, c_stick_y);
+            state.c_stick_up.Assign(direction.up);
+            state.c_stick_down.Assign(direction.down);
+            state.c_stick_left.Assign(direction.left);
+            state.c_stick_right.Assign(direction.right);
+        }
     }
 
     // TODO (wwylele): implement raw C-stick data for raw_c_stick = true

--- a/src/core/hle/service/ir/ir_rst.h
+++ b/src/core/hle/service/ir/ir_rst.h
@@ -21,6 +21,10 @@ namespace Core {
 struct TimingEventType;
 };
 
+namespace Service::HID {
+class ArticBaseController;
+};
+
 namespace Service::IR {
 
 union PadState {
@@ -41,6 +45,10 @@ public:
     explicit IR_RST(Core::System& system);
     ~IR_RST();
     void ReloadInputDevices();
+
+    void UseArticController(const std::shared_ptr<Service::HID::ArticBaseController>& ac) {
+        artic_controller = ac;
+    }
 
 private:
     /**
@@ -87,6 +95,8 @@ private:
     std::atomic<bool> is_device_reload_pending{false};
     bool raw_c_stick{false};
     int update_period{0};
+
+    std::shared_ptr<Service::HID::ArticBaseController> artic_controller = nullptr;
 
     template <class Archive>
     void serialize(Archive& ar, const unsigned int);

--- a/src/core/hle/service/ir/ir_user.cpp
+++ b/src/core/hle/service/ir/ir_user.cpp
@@ -480,6 +480,12 @@ void IR_USER::ReloadInputDevices() {
     extra_hid->RequestInputDevicesReload();
 }
 
+void IR_USER::UseArticController(const std::shared_ptr<Service::HID::ArticBaseController>& ac) {
+    if (extra_hid.get()) {
+        extra_hid->UseArticController(ac);
+    }
+}
+
 IRDevice::IRDevice(SendFunc send_func_) : send_func(send_func_) {}
 IRDevice::~IRDevice() = default;
 

--- a/src/core/hle/service/ir/ir_user.h
+++ b/src/core/hle/service/ir/ir_user.h
@@ -14,6 +14,10 @@ class Event;
 class SharedMemory;
 } // namespace Kernel
 
+namespace Service::HID {
+class ArticBaseController;
+};
+
 namespace Service::IR {
 
 class BufferManager;
@@ -56,6 +60,8 @@ public:
     ~IR_USER();
 
     void ReloadInputDevices();
+
+    void UseArticController(const std::shared_ptr<Service::HID::ArticBaseController>& ac);
 
 private:
     /**

--- a/src/core/loader/artic.cpp
+++ b/src/core/loader/artic.cpp
@@ -27,6 +27,7 @@
 #include "core/hle/service/cfg/cfg_u.h"
 #include "core/hle/service/fs/archive.h"
 #include "core/hle/service/fs/fs_user.h"
+#include "core/hle/service/hid/hid_user.h"
 #include "core/loader/artic.h"
 #include "core/loader/smdh.h"
 #include "core/memory.h"
@@ -359,6 +360,13 @@ ResultStatus Apploader_Artic::Load(std::shared_ptr<Kernel::Process>& process) {
     auto amapp = system.ServiceManager().GetService<Service::AM::AM_APP>("am:app");
     if (amapp.get()) {
         amapp->UseArticClient(client);
+    }
+
+    if (Settings::values.use_artic_base_controller.GetValue()) {
+        auto hid_user = system.ServiceManager().GetService<Service::HID::User>("hid:USER");
+        if (hid_user.get()) {
+            hid_user->GetModule()->UseArticClient(client);
+        }
     }
 
     ParseRegionLockoutInfo(ncch_program_id);


### PR DESCRIPTION
Adds the ability to use the 3DS running the Artic Base Server as a controller.

The following works:
- Buttons
- Touch screen
- Accelerometer and gyroscope
- New 3DS specific buttons

The following doesn't work:
- Circle pad pro on the old 3ds (games that use it work if played through a new 3ds)
- Microphone and camera (no plans to add support)

The option is disabled by default and can be enabled from the controls tab in emulation settings.