### PR TITLE
Artic Base: Fix issue when 0 bytes are read from file

### DIFF
--- a/src/core/file_sys/archive_artic.cpp
+++ b/src/core/file_sys/archive_artic.cpp
@@ -405,11 +405,12 @@ ResultVal<std::size_t> ArticFileBackend::Read(u64 offset, std::size_t length, u8
             return res;
 
         auto read_buff = resp->GetResponseBuffer(0);
-        if (!read_buff.has_value())
-            return Result(-1);
-        size_t actually_read = read_buff->second;
+        size_t actually_read = 0;
+        if (read_buff.has_value()) {
+            actually_read = read_buff->second;
+            memcpy(buffer + read_amount, read_buff->first, actually_read);
+        }
 
-        memcpy(buffer + read_amount, read_buff->first, actually_read);
         read_amount += actually_read;
         if (actually_read != to_read)
             break;

--- a/src/core/file_sys/artic_cache.cpp
+++ b/src/core/file_sys/artic_cache.cpp
@@ -200,11 +200,12 @@ ResultVal<size_t> ArticCache::ReadFromArtic(s32 file_handle, u8* buffer, size_t 
             return res;
 
         auto read_buff = resp->GetResponseBuffer(0);
-        if (!read_buff.has_value())
-            return Result(-1);
-        size_t actually_read = read_buff->second;
+        size_t actually_read = 0;
+        if (read_buff.has_value()) {
+            actually_read = read_buff->second;
+            memcpy(buffer + read_amount, read_buff->first, actually_read);
+        }
 
-        memcpy(buffer + read_amount, read_buff->first, actually_read);
         read_amount += actually_read;
         if (actually_read != to_read)
             break;


### PR DESCRIPTION
Fixes an issue when a `FSFILE_Read` operation returns 0 bytes of data.

Closes #178