### PR TITLE
Use Buttons instead of Axis for D-pad mapping on Android

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -166,13 +166,25 @@ class Settings {
             KEY_CSTICK_AXIS_HORIZONTAL
         )
         val dPadKeys = listOf(
-            KEY_DPAD_AXIS_VERTICAL,
-            KEY_DPAD_AXIS_HORIZONTAL
+//            KEY_DPAD_AXIS_VERTICAL,
+//            KEY_DPAD_AXIS_HORIZONTAL,
+            KEY_BUTTON_UP,
+            KEY_BUTTON_DOWN,
+            KEY_BUTTON_LEFT,
+            KEY_BUTTON_RIGHT
         )
         val axisTitles = listOf(
-            R.string.controller_axis_vertical,
+           R.string.controller_axis_vertical,
             R.string.controller_axis_horizontal
         )
+
+        val dPadTitles = listOf(
+            R.string.direction_up,
+            R.string.direction_down,
+            R.string.direction_left,
+            R.string.direction_right,
+        )
+
         val triggerKeys = listOf(
             KEY_BUTTON_L,
             KEY_BUTTON_R,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -79,6 +79,14 @@ class InputBindingSetting(
             else -> false
         }
 
+    fun isDpadButtons(): Boolean =
+        when (abstractSetting.key) {
+            Settings.KEY_BUTTON_DOWN,
+            Settings.KEY_BUTTON_LEFT,
+            Settings.KEY_BUTTON_UP,
+            Settings.KEY_BUTTON_RIGHT -> true
+            else -> false
+        }
     /**
      * Returns true if this key is for the 3DS L/R or ZL/ZR buttons. Note, these are not real
      * triggers on the 3DS, but we support them as such on a physical gamepad.

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -612,7 +612,7 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
             add(HeaderSetting(R.string.controller_dpad))
             Settings.dPadKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
-                add(InputBindingSetting(button, Settings.axisTitles[i]))
+                add(InputBindingSetting(button, Settings.dPadTitles[i]))
             }
 
             add(HeaderSetting(R.string.controller_triggers))

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -110,6 +110,10 @@
     <string name="controller_dpad">D-Pad</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
+    <string name="direction_up">Up</string>
+    <string name="direction_down">Down</string>
+    <string name="direction_left">Left</string>
+    <string name="direction_right">Right</string>
     <string name="input_dialog_title">Bind %1$s %2$s</string>
     <string name="input_dialog_description">Press or move an input.</string>
     <string name="input_binding">Input Binding</string>


### PR DESCRIPTION
This PR will fix issues #172 and #17 , which I confirmed were a problem. Instead of using Axis+ and Axis- inputs for the d-pad, it uses button inputs instead. 

I tested with every controller I have available right now - an 8bitdo micro in switch pro mode (which did not work before but does now) and android mode (which did work before), a Dualshock 4, and my Gamesir g8 -  and they all work fine with this change. I believe that every controller that outputs an axis for the d-pad will ALSO output button presses, so this shouldn't break for any controller.

The only negative is that users will need to map their controller again - it did not maintain the old mapping for me even when the inputs were the same. I'm not sure why, to be honest, but it seems like a pretty minor ask all things considered.

I am still considering a more thorough update to this system that would allow for mapping buttons to the other sticks as well - enabling, for example, keyboard controls on android - but for now this simpler update will solve the primary problem.