### PR TITLE
Add instant log flush option

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -13,7 +13,8 @@ enum class BooleanSetting(
     ASYNC_SHADERS("async_shader_compilation", Settings.SECTION_RENDERER, false),
     PLUGIN_LOADER("plugin_loader", Settings.SECTION_SYSTEM, false),
     ALLOW_PLUGIN_LOADER("allow_plugin_loader", Settings.SECTION_SYSTEM, true),
-    SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false);
+    SWAP_SCREEN("swap_screen", Settings.SECTION_LAYOUT, false),
+    INSTANT_DEBUG_LOG("instant_debug_log", Settings.SECTION_DEBUG, false);
 
     override var boolean: Boolean = defaultValue
 

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -986,6 +986,15 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                     IntSetting.DEBUG_RENDERER.defaultValue
                 )
             )
+            add(
+                SwitchSetting(
+                    BooleanSetting.INSTANT_DEBUG_LOG,
+                    R.string.instant_debug_log,
+                    R.string.instant_debug_log_desc,
+                    BooleanSetting.INSTANT_DEBUG_LOG.key,
+                    BooleanSetting.INSTANT_DEBUG_LOG.defaultValue
+                )
+            )
         }
     }
 

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -262,6 +262,7 @@ void Config::ReadValues() {
     ReadSetting("Debugging", Settings::values.renderer_debug);
     ReadSetting("Debugging", Settings::values.use_gdbstub);
     ReadSetting("Debugging", Settings::values.gdbstub_port);
+    ReadSetting("Debugging", Settings::values.instant_debug_log);
 
     for (const auto& service_module : Service::service_module_map) {
         bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.name, false);

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -357,6 +357,10 @@ renderer_debug =
 use_gdbstub=false
 gdbstub_port=24689
 
+# Flush log output on every message
+# Immediately commits the debug log to file. Use this if citra crashes and the log output is being cut.
+instant_debug_log =
+
 # To LLE a service module add "LLE\<module name>=true"
 
 [WebService]

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -703,5 +703,7 @@
     <string name="miscellaneous">Miscellaneous</string>
     <string name="use_artic_base_controller">Use Artic Controller when connected to Artic Base Server</string>
     <string name="use_artic_base_controller_desc">Use the controls provided by Artic Base Server when connected to it instead of the configured input device.</string>
+    <string name="instant_debug_log">Flush log output on every message</string>
+    <string name="instant_debug_log_desc">Immediately commits the debug log to file. Use this if citra crashes and the log output is being cut.</string>
 
 </resources>

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -126,6 +126,7 @@ void Config::ReadValues() {
     Settings::values.current_input_profile.udp_input_port =
         static_cast<u16>(sdl2_config->GetInteger("Controls", "udp_input_port",
                                                  InputCommon::CemuhookUDP::DEFAULT_PORT));
+    ReadSetting("Controls", Settings::values.use_artic_base_controller);
 
     // Core
     ReadSetting("Core", Settings::values.use_cpu_jit);
@@ -322,6 +323,7 @@ void Config::ReadValues() {
     ReadSetting("Debugging", Settings::values.renderer_debug);
     ReadSetting("Debugging", Settings::values.use_gdbstub);
     ReadSetting("Debugging", Settings::values.gdbstub_port);
+    ReadSetting("Debugging", Settings::values.instant_debug_log);
 
     for (const auto& service_module : Service::service_module_map) {
         bool use_lle = sdl2_config->GetBoolean("Debugging", "LLE\\" + service_module.name, false);

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -494,6 +494,7 @@ void Config::ReadDebuggingValues() {
     ReadBasicSetting(Settings::values.gdbstub_port);
     ReadBasicSetting(Settings::values.renderer_debug);
     ReadBasicSetting(Settings::values.dump_command_buffers);
+    ReadBasicSetting(Settings::values.instant_debug_log);
 
     qt_config->beginGroup(QStringLiteral("LLE"));
     for (const auto& service_module : Service::service_module_map) {
@@ -1031,6 +1032,7 @@ void Config::SaveDebuggingValues() {
     WriteBasicSetting(Settings::values.use_gdbstub);
     WriteBasicSetting(Settings::values.gdbstub_port);
     WriteBasicSetting(Settings::values.renderer_debug);
+    WriteBasicSetting(Settings::values.instant_debug_log);
 
     qt_config->beginGroup(QStringLiteral("LLE"));
     for (const auto& service_module : Settings::values.lle_modules) {

--- a/src/citra_qt/configuration/configure_debug.cpp
+++ b/src/citra_qt/configuration/configure_debug.cpp
@@ -121,6 +121,7 @@ void ConfigureDebug::SetConfiguration() {
         SettingsToSlider(Settings::values.cpu_clock_percentage.GetValue()));
     ui->clock_display_label->setText(
         QStringLiteral("%1%").arg(Settings::values.cpu_clock_percentage.GetValue()));
+    ui->instant_debug_log->setChecked(Settings::values.instant_debug_log.GetValue());
 }
 
 void ConfigureDebug::ApplyConfiguration() {
@@ -138,6 +139,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.delay_start_for_lle_modules = ui->delay_start_for_lle_modules->isChecked();
     Settings::values.renderer_debug = ui->toggle_renderer_debug->isChecked();
     Settings::values.dump_command_buffers = ui->toggle_dump_command_buffers->isChecked();
+    Settings::values.instant_debug_log = ui->instant_debug_log->isChecked();
 
     ConfigurationShared::ApplyPerGameSetting(
         &Settings::values.cpu_clock_percentage, ui->clock_speed_combo,

--- a/src/citra_qt/configuration/configure_debug.ui
+++ b/src/citra_qt/configuration/configure_debug.ui
@@ -117,6 +117,16 @@
         </item>
        </layout>
       </item>
+      <item>
+        <widget class="QCheckBox" name="instant_debug_log">
+          <property name="text">
+            <string>Flush log output on every message</string>
+          </property>
+          <property name="toolTip">
+            <string>&lt;html&gt;&lt;body&gt;Immediately commits the debug log to file. Use this if citra crashes and the log output is being cut.&lt;br&gt;Enabling this feature will decrease performance, only use it for debugging purposes.&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+        </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -147,6 +147,7 @@ void LogSettings() {
     log_setting("Debugging_DelayStartForLLEModules", values.delay_start_for_lle_modules.GetValue());
     log_setting("Debugging_UseGdbstub", values.use_gdbstub.GetValue());
     log_setting("Debugging_GdbstubPort", values.gdbstub_port.GetValue());
+    log_setting("Debugging_InstantDebugLog", values.instant_debug_log.GetValue());
 }
 
 bool IsConfiguringGlobal() {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -542,6 +542,7 @@ struct Values {
     Setting<bool> delay_start_for_lle_modules{true, "delay_start_for_lle_modules"};
     Setting<bool> use_gdbstub{false, "use_gdbstub"};
     Setting<u16> gdbstub_port{24689, "gdbstub_port"};
+    Setting<bool> instant_debug_log{false, "instant_debug_log"};
 
     // Miscellaneous
     Setting<std::string> log_filter{"*:Info", "log_filter"};


### PR DESCRIPTION
Adds an option that immediately writes and flushes every single log message. Useful for better debugging some kinds of crashes as sometimes the log output gets cut.