### PR TITLE
pica: Move mutex lock below tracing check on register write

### DIFF
--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -272,10 +272,10 @@ void StartPicaTracing() {
 }
 
 void OnPicaRegWrite(u16 cmd_id, u16 mask, u32 value) {
-    std::lock_guard lock(pica_trace_mutex);
-
     if (!g_is_pica_tracing)
         return;
+
+    std::lock_guard lock(pica_trace_mutex);
 
     pica_trace->writes.push_back(PicaTrace::Write{cmd_id, mask, value});
 }


### PR DESCRIPTION
A mutex was being unnecessary locked on every GPU register write, even if the debug tracing feature was disabled. Fixed by moving the lock below the tracing enabled check.