### PR TITLE
Add "Steps per hour" system setting

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -26,6 +26,7 @@ enum class IntSetting(
     AUDIO_INPUT_TYPE("output_type", Settings.SECTION_AUDIO, 0),
     NEW_3DS("is_new_3ds", Settings.SECTION_SYSTEM, 1),
     LLE_APPLETS("lle_applets", Settings.SECTION_SYSTEM, 0),
+    STEPS_PER_HOUR("steps_per_hour", Settings.SECTION_SYSTEM, 0),
     CPU_CLOCK_SPEED("cpu_clock_percentage", Settings.SECTION_CORE, 100),
     LINEAR_FILTERING("filter_mode", Settings.SECTION_RENDERER, 1),
     SHADERS_ACCURATE_MUL("shaders_accurate_mul", Settings.SECTION_RENDERER, 0),

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/IntSetting.kt
@@ -26,7 +26,6 @@ enum class IntSetting(
     AUDIO_INPUT_TYPE("output_type", Settings.SECTION_AUDIO, 0),
     NEW_3DS("is_new_3ds", Settings.SECTION_SYSTEM, 1),
     LLE_APPLETS("lle_applets", Settings.SECTION_SYSTEM, 0),
-    STEPS_PER_HOUR("steps_per_hour", Settings.SECTION_SYSTEM, 0),
     CPU_CLOCK_SPEED("cpu_clock_percentage", Settings.SECTION_CORE, 100),
     LINEAR_FILTERING("filter_mode", Settings.SECTION_RENDERER, 1),
     SHADERS_ACCURATE_MUL("shaders_accurate_mul", Settings.SECTION_RENDERER, 0),

--- a/src/android/app/src/main/jni/config.cpp
+++ b/src/android/app/src/main/jni/config.cpp
@@ -223,6 +223,7 @@ void Config::ReadValues() {
     ReadSetting("System", Settings::values.init_ticks_override);
     ReadSetting("System", Settings::values.plugin_loader_enabled);
     ReadSetting("System", Settings::values.allow_plugin_loader);
+    ReadSetting("System", Settings::values.steps_per_hour);
 
     // Camera
     using namespace Service::CAM;

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -307,6 +307,9 @@ init_ticks_type =
 # Defaults to 0.
 init_ticks_override =
 
+# Number of steps per hour reported by the pedometer (Default 0)
+steps_per_hour =
+
 # Plugin loader state, if enabled plugins will be loaded from the SD card.
 # You can also set if homebrew apps are allowed to enable the plugin loader
 plugin_loader =

--- a/src/android/app/src/main/jni/default_ini.h
+++ b/src/android/app/src/main/jni/default_ini.h
@@ -307,7 +307,8 @@ init_ticks_type =
 # Defaults to 0.
 init_ticks_override =
 
-# Number of steps per hour reported by the pedometer (Default 0)
+# Number of steps per hour reported by the pedometer.
+# Defaults to 0.
 steps_per_hour =
 
 # Plugin loader state, if enabled plugins will be loaded from the SD card.

--- a/src/citra/config.cpp
+++ b/src/citra/config.cpp
@@ -232,6 +232,7 @@ void Config::ReadValues() {
     ReadSetting("System", Settings::values.init_ticks_override);
     ReadSetting("System", Settings::values.plugin_loader_enabled);
     ReadSetting("System", Settings::values.allow_plugin_loader);
+    ReadSetting("System", Settings::values.steps_per_hour);
 
     {
         constexpr const char* default_init_time_offset = "0 00:00:00";

--- a/src/citra/default_ini.h
+++ b/src/citra/default_ini.h
@@ -319,6 +319,10 @@ init_ticks_type =
 # Defaults to 0.
 init_ticks_override =
 
+# Number of steps per hour reported by the pedometer.
+# Defaults to 0.
+steps_per_hour =
+
 [Camera]
 # Which camera engine to use for the right outer camera
 # blank (default): a dummy camera that always returns black image

--- a/src/citra_qt/configuration/config.cpp
+++ b/src/citra_qt/configuration/config.cpp
@@ -713,6 +713,7 @@ void Config::ReadSystemValues() {
         ReadBasicSetting(Settings::values.init_time_offset);
         ReadBasicSetting(Settings::values.init_ticks_type);
         ReadBasicSetting(Settings::values.init_ticks_override);
+        ReadBasicSetting(Settings::values.steps_per_hour);
         ReadBasicSetting(Settings::values.plugin_loader_enabled);
         ReadBasicSetting(Settings::values.allow_plugin_loader);
     }
@@ -1219,6 +1220,7 @@ void Config::SaveSystemValues() {
         WriteBasicSetting(Settings::values.init_time_offset);
         WriteBasicSetting(Settings::values.init_ticks_type);
         WriteBasicSetting(Settings::values.init_ticks_override);
+        WriteBasicSetting(Settings::values.steps_per_hour);
         WriteBasicSetting(Settings::values.plugin_loader_enabled);
         WriteBasicSetting(Settings::values.allow_plugin_loader);
     }

--- a/src/citra_qt/configuration/configure_system.cpp
+++ b/src/citra_qt/configuration/configure_system.cpp
@@ -328,6 +328,8 @@ void ConfigureSystem::SetConfiguration() {
     ui->edit_init_ticks_value->setText(
         QString::number(Settings::values.init_ticks_override.GetValue()));
 
+    ui->spinBox_steps_per_hour->setValue(Settings::values.steps_per_hour.GetValue());
+
     cfg = Service::CFG::GetModule(system);
     ReadSystemSettings();
 
@@ -459,6 +461,8 @@ void ConfigureSystem::ApplyConfiguration() {
             static_cast<Settings::InitTicks>(ui->combo_init_ticks_type->currentIndex());
         Settings::values.init_ticks_override =
             static_cast<s64>(ui->edit_init_ticks_value->text().toLongLong());
+
+        Settings::values.steps_per_hour = static_cast<u16>(ui->spinBox_steps_per_hour->value());
 
         s64 time_offset_time = ui->edit_init_time_offset_time->time().msecsSinceStartOfDay() / 1000;
         s64 time_offset_days = ui->edit_init_time_offset_days->value() * 86400;
@@ -631,8 +635,10 @@ void ConfigureSystem::SetupPerGameUI() {
     ui->label_language->setVisible(false);
     ui->label_country->setVisible(false);
     ui->label_play_coins->setVisible(false);
+    ui->label_steps_per_hour->setVisible(false);
     ui->edit_username->setVisible(false);
     ui->spinBox_play_coins->setVisible(false);
+    ui->spinBox_steps_per_hour->setVisible(false);
     ui->combo_birthday->setVisible(false);
     ui->combo_birthmonth->setVisible(false);
     ui->combo_init_clock->setVisible(false);

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -395,7 +395,7 @@
             <item row="13" column="0">
               <widget class="QLabel" name="label_steps_per_hour">
                 <property name="text">
-                  <string>Steps per hour:</string>
+                  <string>Pedometer steps per hour:</string>
                 </property>
               </widget>
             </item>

--- a/src/citra_qt/configuration/configure_system.ui
+++ b/src/citra_qt/configuration/configure_system.ui
@@ -392,21 +392,35 @@
               </property>
              </widget>
             </item>
+            <item row="13" column="0">
+              <widget class="QLabel" name="label_steps_per_hour">
+                <property name="text">
+                  <string>Steps per hour:</string>
+                </property>
+              </widget>
+            </item>
             <item row="13" column="1">
+              <widget class="QSpinBox" name="spinBox_steps_per_hour">
+                <property name="maximum">
+                  <number>9999</number>
+                </property>
+              </widget>
+            </item>
+            <item row="14" column="1">
              <widget class="QCheckBox" name="toggle_system_setup">
               <property name="text">
                <string>Run System Setup when Home Menu is launched</string>
               </property>
              </widget>
             </item>
-            <item row="14" column="0">
+            <item row="15" column="0">
              <widget class="QLabel" name="label_console_id">
               <property name="text">
                <string>Console ID:</string>
               </property>
              </widget>
             </item>
-            <item row="14" column="1">
+            <item row="15" column="1">
              <widget class="QPushButton" name="button_regenerate_console_id">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -422,35 +436,35 @@
               </property>
              </widget>
             </item>
-            <item row="15" column="0">
+            <item row="16" column="0">
              <widget class="QLabel" name="label_plugin_loader">
               <property name="text">
                <string>3GX Plugin Loader:</string>
               </property>
              </widget>
             </item>
-            <item row="15" column="1">
+            <item row="16" column="1">
              <widget class="QCheckBox" name="plugin_loader">
               <property name="text">
                <string>Enable 3GX plugin loader</string>
               </property>
              </widget>
             </item>
-            <item row="16" column="1">
+            <item row="17" column="1">
              <widget class="QCheckBox" name="allow_plugin_loader">
               <property name="text">
                <string>Allow games to change plugin loader state</string>
               </property>
              </widget>
             </item>
-            <item row="17" column="0">
+            <item row="18" column="0">
              <widget class="QLabel" name="label_nus_download">
               <property name="text">
                <string>Download System Files from Nitendo servers</string>
               </property>
              </widget>
             </item>
-            <item row="17" column="1">
+            <item row="18" column="1">
              <widget class="QWidget" name="body_nus_download">
               <layout class="QHBoxLayout" name="horizontalLayout_nus_download">
                <item>
@@ -692,6 +706,7 @@
   <tabstop>combo_init_clock</tabstop>
   <tabstop>edit_init_time</tabstop>
   <tabstop>spinBox_play_coins</tabstop>
+  <tabstop>spinBox_steps_per_hour</tabstop>
   <tabstop>button_regenerate_console_id</tabstop>
  </tabstops>
  <resources/>

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -448,6 +448,7 @@ struct Values {
     Setting<s64> init_ticks_override{0, "init_ticks_override"};
     Setting<bool> plugin_loader_enabled{false, "plugin_loader"};
     Setting<bool> allow_plugin_loader{true, "allow_plugin_loader"};
+    Setting<u16> steps_per_hour{0, "steps_per_hour"};
 
     // Renderer
     SwitchableSetting<GraphicsAPI, true> graphics_api {

--- a/src/core/hle/service/ptm/ptm.cpp
+++ b/src/core/hle/service/ptm/ptm.cpp
@@ -84,9 +84,8 @@ void Module::Interface::GetStepHistory(Kernel::HLERequestContext& ctx) {
     ASSERT_MSG(sizeof(u16) * hours == buffer.GetSize(),
                "Buffer for steps count has incorrect size");
 
-    // Stub: set zero steps count for every hour
+    const u16_le steps_per_hour = Settings::values.steps_per_hour.GetValue();
     for (u32 i = 0; i < hours; ++i) {
-        const u16_le steps_per_hour = 0;
         buffer.Write(&steps_per_hour, i * sizeof(u16), sizeof(u16));
     }
 


### PR DESCRIPTION
This implements a "Steps per hour" system setting to be returned from `PTM:GetStepHistory`, as described in issue #208.

Currently the setting is global (i.e. not per-game).