### PR TITLE
Android: add the titleId to the game card.

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -148,14 +148,14 @@ class GameAdapter(private val activity: AppCompatActivity) :
             } else {
                 View.VISIBLE
             }
-            binding.textCompany.visibility = if (game.company.isEmpty()) {
+            binding.textGameId.visibility = if (game.titleId == 0L) {
                 View.GONE
             } else {
                 View.VISIBLE
             }
 
             binding.textGameTitle.text = game.title
-            binding.textCompany.text = game.company
+            binding.textGameId.text = String.format("ID: %016X", game.titleId)
             binding.textFilename.text = game.filename
 
             val backgroundColorId =
@@ -178,8 +178,8 @@ class GameAdapter(private val activity: AppCompatActivity) :
                     binding.textGameTitle.ellipsize = TextUtils.TruncateAt.MARQUEE
                     binding.textGameTitle.isSelected = true
 
-                    binding.textCompany.ellipsize = TextUtils.TruncateAt.MARQUEE
-                    binding.textCompany.isSelected = true
+                    binding.textGameId.ellipsize = TextUtils.TruncateAt.MARQUEE
+                    binding.textGameId.isSelected = true
 
                     binding.textFilename.ellipsize = TextUtils.TruncateAt.MARQUEE
                     binding.textFilename.isSelected = true

--- a/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/adapters/GameAdapter.kt
@@ -148,6 +148,11 @@ class GameAdapter(private val activity: AppCompatActivity) :
             } else {
                 View.VISIBLE
             }
+            binding.textCompany.visibility = if (game.company.isEmpty()) {
+                View.GONE
+            } else {
+                View.VISIBLE
+            }
             binding.textGameId.visibility = if (game.titleId == 0L) {
                 View.GONE
             } else {
@@ -155,6 +160,7 @@ class GameAdapter(private val activity: AppCompatActivity) :
             }
 
             binding.textGameTitle.text = game.title
+            binding.textCompany.text = game.company
             binding.textGameId.text = String.format("ID: %016X", game.titleId)
             binding.textFilename.text = game.filename
 
@@ -177,6 +183,9 @@ class GameAdapter(private val activity: AppCompatActivity) :
                 {
                     binding.textGameTitle.ellipsize = TextUtils.TruncateAt.MARQUEE
                     binding.textGameTitle.isSelected = true
+
+                    binding.textCompany.ellipsize = TextUtils.TruncateAt.MARQUEE
+                    binding.textCompany.isSelected = true
 
                     binding.textGameId.ellipsize = TextUtils.TruncateAt.MARQUEE
                     binding.textGameId.isSelected = true

--- a/src/android/app/src/main/res/layout/card_game.xml
+++ b/src/android/app/src/main/res/layout/card_game.xml
@@ -52,7 +52,7 @@
                 tools:text="The Legend of Zelda\nOcarina of Time 3D" />
 
             <TextView
-                android:id="@+id/text_company"
+                android:id="@+id/text_game_id"
                 style="@style/TextAppearance.Material3.BodySmall"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -61,7 +61,7 @@
                 android:marqueeRepeatLimit="marquee_forever"
                 android:ellipsize="none"
                 android:requiresFadingEdge="horizontal"
-                tools:text="Nintendo" />
+                tools:text="0004000000033400" />
 
             <TextView
                 android:id="@+id/text_filename"

--- a/src/android/app/src/main/res/layout/card_game.xml
+++ b/src/android/app/src/main/res/layout/card_game.xml
@@ -22,8 +22,8 @@
 
         <ImageView
             android:id="@+id/image_game_screen"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
+            android:layout_width="75dp"
+            android:layout_height="75dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
@@ -50,6 +50,18 @@
                 android:ellipsize="none"
                 android:requiresFadingEdge="horizontal"
                 tools:text="The Legend of Zelda\nOcarina of Time 3D" />
+
+            <TextView
+                android:id="@+id/text_company"
+                style="@style/TextAppearance.Material3.BodySmall"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAlignment="viewStart"
+                android:singleLine="true"
+                android:marqueeRepeatLimit="marquee_forever"
+                android:ellipsize="none"
+                android:requiresFadingEdge="horizontal"
+                tools:text="Nintendo" />
 
             <TextView
                 android:id="@+id/text_game_id"


### PR DESCRIPTION
Compared to game companies, users may be more interested in knowing what the title ID of this game is, 
as it can help them find game saves and the cheat file. 

In fact, many people have been troubled by not being able to find a game save location because they don't know what title ID is.

This PR will directly display the title ID in the game card, making it easier for users to find this ID. It replaced the game company.

old:
![Screenshot_20240806_093212_old](https://github.com/user-attachments/assets/a1bf3540-c5a2-4ca7-b0a7-c61faf39c09d)

new:
![Screenshot_20240806_112050_new](https://github.com/user-attachments/assets/a7d24770-87ab-406f-a6d7-28fce5184817)

