### PR TITLE
shader_jit_a64: Optimize conditional tests

### DIFF
--- a/src/video_core/shader/shader_jit_a64_compiler.h
+++ b/src/video_core/shader/shader_jit_a64_compiler.h
@@ -94,6 +94,9 @@ private:
      */
     void Compile_SanitizedMul(oaknut::QReg src1, oaknut::QReg src2, oaknut::QReg scratch0);
 
+    /**
+     * Emits the code to evaluate a conditional instruction and update the host's EQ/NE status-flags
+     */
     void Compile_EvaluateCondition(Instruction instr);
     void Compile_UniformCondition(Instruction instr);
 


### PR DESCRIPTION
These conditional tests are a 1:1 translation from the x64 code but do not have to be. Reference-values are known at emit-time and can be embedded as an immediate into an `EOR` instruction rather than moved into a register. The `TST` instruction can be utilized to more optimally test and update the `EQ`/`NE` status flags.