### PR TITLE
shader_jit_a64: Compact host executable memory

### DIFF
--- a/src/common/aarch64/oaknut_abi.h
+++ b/src/common/aarch64/oaknut_abi.h
@@ -78,7 +78,8 @@ inline ABIFrameInfo ABI_CalculateFrameSize(std::bitset<64> regs, std::size_t fra
     return ABIFrameInfo{static_cast<u32>(total_size), static_cast<u32>(fprs_base_subtraction)};
 }
 
-inline void ABI_PushRegisters(oaknut::CodeGenerator& code, std::bitset<64> regs,
+template <typename Policy>
+inline void ABI_PushRegisters(oaknut::BasicCodeGenerator<Policy>& code, std::bitset<64> regs,
                               std::size_t frame_size = 0) {
     using namespace oaknut;
     using namespace oaknut::util;
@@ -137,7 +138,8 @@ inline void ABI_PushRegisters(oaknut::CodeGenerator& code, std::bitset<64> regs,
     }
 }
 
-inline void ABI_PopRegisters(oaknut::CodeGenerator& code, std::bitset<64> regs,
+template <typename Policy>
+inline void ABI_PopRegisters(oaknut::BasicCodeGenerator<Policy>& code, std::bitset<64> regs,
                              std::size_t frame_size = 0) {
     using namespace oaknut;
     using namespace oaknut::util;

--- a/src/common/aarch64/oaknut_util.h
+++ b/src/common/aarch64/oaknut_util.h
@@ -23,8 +23,15 @@ inline bool IsWithin128M(const oaknut::CodeGenerator& code, uintptr_t target) {
     return IsWithin128M(code.xptr<uintptr_t>(), target);
 }
 
-template <typename T>
-inline void CallFarFunction(oaknut::CodeGenerator& code, const T f) {
+inline bool IsWithin128M(const oaknut::VectorCodeGenerator& code, uintptr_t target) {
+    // VectorCodeGenerator is not the final executable memory, so no assumption can be
+    // made about how far pointers are from each other.
+    // Always assume far-calls
+    return false;
+}
+
+template <typename T, typename Policy>
+inline void CallFarFunction(oaknut::BasicCodeGenerator<Policy>& code, const T f) {
     static_assert(std::is_pointer_v<T>, "Argument must be a (function) pointer.");
     const std::uintptr_t addr = reinterpret_cast<std::uintptr_t>(f);
     if (IsWithin128M(code, addr)) {

--- a/src/video_core/shader/shader_jit_a64_compiler.h
+++ b/src/video_core/shader/shader_jit_a64_compiler.h
@@ -30,20 +30,17 @@ struct ShaderUnit;
 
 namespace Pica::Shader {
 
-/// Memory allocated for each compiled shader
-constexpr std::size_t MAX_SHADER_SIZE = MAX_PROGRAM_CODE_LENGTH * 256;
-
 /**
  * This class implements the shader JIT compiler. It recompiles a Pica shader program into x86_64
  * code that can be executed on the host machine directly.
  */
-class JitShader : private oaknut::CodeBlock, private oaknut::CodeGenerator {
+class JitShader : public oaknut::VectorCodeGenerator {
 public:
     JitShader();
 
     void Run(const ShaderSetup& setup, ShaderUnit& state, u32 offset) const {
         program(&setup.uniforms, &state,
-                reinterpret_cast<std::byte*>(oaknut::CodeBlock::ptr()) +
+                reinterpret_cast<const std::byte*>(code_mem->ptr()) +
                     instruction_labels[offset].offset());
     }
 
@@ -81,6 +78,9 @@ public:
     void Compile_SETE(Instruction instr);
 
 private:
+    std::vector<u32> code_vec;
+    std::unique_ptr<oaknut::CodeBlock> code_mem;
+
     void Compile_Block(u32 end);
     void Compile_NextInstr();
 


### PR DESCRIPTION
Generates position-independent assembly to allow for code to be generated first within a `std::vector` before copying into executable memory. Allows for more compact memory-usage rather than allocating 1MiB of executable code for each shader. Saves up to ~1MiB for _each_ shader.