### PR TITLE
shader_jit: Fix/optimize conditional evaluation

### DIFF
--- a/src/video_core/pica/shader_unit.cpp
+++ b/src/video_core/pica/shader_unit.cpp
@@ -9,10 +9,7 @@
 
 namespace Pica {
 
-ShaderUnit::ShaderUnit(GeometryEmitter* emitter) : emitter_ptr{emitter} {
-    const Common::Vec4<f24> temp_vec{f24::Zero(), f24::Zero(), f24::Zero(), f24::One()};
-    temporary.fill(temp_vec);
-}
+ShaderUnit::ShaderUnit(GeometryEmitter* emitter) : emitter_ptr{emitter} {}
 
 ShaderUnit::~ShaderUnit() = default;
 

--- a/src/video_core/pica/shader_unit.h
+++ b/src/video_core/pica/shader_unit.h
@@ -46,11 +46,11 @@ struct ShaderUnit {
     }
 
 public:
-    s32 address_registers[3];
-    bool conditional_code[2];
-    alignas(16) std::array<Common::Vec4<f24>, 16> input;
-    alignas(16) std::array<Common::Vec4<f24>, 16> temporary;
-    alignas(16) std::array<Common::Vec4<f24>, 16> output;
+    s32 address_registers[3] = {};
+    bool conditional_code[2] = {};
+    alignas(16) std::array<Common::Vec4<f24>, 16> input = {};
+    alignas(16) std::array<Common::Vec4<f24>, 16> temporary = {};
+    alignas(16) std::array<Common::Vec4<f24>, 16> output = {};
     GeometryEmitter* emitter_ptr;
 
 private:

--- a/src/video_core/shader/shader_interpreter.cpp
+++ b/src/video_core/shader/shader_interpreter.cpp
@@ -52,9 +52,6 @@ static void RunInterpreter(const ShaderSetup& setup, ShaderUnit& state,
     boost::circular_buffer<LoopStackElement> loop_stack(4);
     u32 program_counter = entry_point;
 
-    state.conditional_code[0] = false;
-    state.conditional_code[1] = false;
-
     const auto do_if = [&](Instruction instr, bool condition) {
         if (condition) {
             if_stack.push_back({

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -401,29 +401,29 @@ void JitShader::Compile_EvaluateCondition(Instruction instr) {
     // Note: NXOR is used below to check for equality
     switch (instr.flow_control.op) {
     case Instruction::FlowControlType::Or:
-        mov(eax, COND0);
-        mov(ebx, COND1);
-        xor_(eax, (instr.flow_control.refx.Value() ^ 1));
-        xor_(ebx, (instr.flow_control.refy.Value() ^ 1));
-        or_(eax, ebx);
+        mov(al, COND0.cvt8());
+        mov(bl, COND1.cvt8());
+        xor_(al, (instr.flow_control.refx.Value() ^ 1));
+        xor_(bl, (instr.flow_control.refy.Value() ^ 1));
+        or_(al, bl);
         break;
 
     case Instruction::FlowControlType::And:
-        mov(eax, COND0);
-        mov(ebx, COND1);
-        xor_(eax, (instr.flow_control.refx.Value() ^ 1));
-        xor_(ebx, (instr.flow_control.refy.Value() ^ 1));
-        and_(eax, ebx);
+        mov(al, COND0);
+        mov(bl, COND1);
+        xor_(al, (instr.flow_control.refx.Value() ^ 1));
+        xor_(bl, (instr.flow_control.refy.Value() ^ 1));
+        and_(al, bl);
         break;
 
     case Instruction::FlowControlType::JustX:
-        mov(eax, COND0);
-        xor_(eax, (instr.flow_control.refx.Value() ^ 1));
+        mov(al, COND0);
+        xor_(al, (instr.flow_control.refx.Value() ^ 1));
         break;
 
     case Instruction::FlowControlType::JustY:
-        mov(eax, COND1);
-        xor_(eax, (instr.flow_control.refy.Value() ^ 1));
+        mov(al, COND1);
+        xor_(al, (instr.flow_control.refy.Value() ^ 1));
         break;
     }
 }

--- a/src/video_core/shader/shader_jit_x64_compiler.cpp
+++ b/src/video_core/shader/shader_jit_x64_compiler.cpp
@@ -1002,8 +1002,8 @@ void JitShader::Compile(const std::array<u32, MAX_PROGRAM_CODE_LENGTH>* program_
     mov(LOOPCOUNT_REG, dword[STATE + offsetof(ShaderUnit, address_registers[2])]);
 
     // Load conditional code
-    mov(COND0, byte[STATE + offsetof(ShaderUnit, conditional_code[0])]);
-    mov(COND1, byte[STATE + offsetof(ShaderUnit, conditional_code[1])]);
+    movzx(COND0, byte[STATE + offsetof(ShaderUnit, conditional_code[0])]);
+    movzx(COND1, byte[STATE + offsetof(ShaderUnit, conditional_code[1])]);
 
     // Used to set a register to one
     static const __m128 one = {1.f, 1.f, 1.f, 1.f};


### PR DESCRIPTION
Fix some of the regressions introduced by https://github.com/PabloMK7/citra/pull/229 and adds a further optimization that can be done at emit-time(COND{0,1} registers can be utilized immediately in the case that the inverted reference value is 0).

This also adds an exhaustive conditional code unit-test to better detect regressions on conditional code.

This also addresses an initialization issue in the Shader Interpreter.