### PR TITLE
qt: Fix default language not being set to the main one the system uses

### DIFF
--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -3093,8 +3093,9 @@ void GMainWindow::LoadTranslation() {
     bool loaded;
 
     if (UISettings::values.language.isEmpty()) {
-        // If the selected language is empty, use system locale
-        loaded = translator.load(QLocale(), {}, {}, QStringLiteral(":/languages/"));
+        //  Use the system's default locale
+        QLocale defaultLocale = QLocale::system();
+        loaded = translator.load(defaultLocale, {}, {}, QStringLiteral(":/languages/"));
     } else {
         // Otherwise load from the specified file
         loaded = translator.load(UISettings::values.language, QStringLiteral(":/languages/"));

--- a/src/citra_qt/main.cpp
+++ b/src/citra_qt/main.cpp
@@ -3093,9 +3093,8 @@ void GMainWindow::LoadTranslation() {
     bool loaded;
 
     if (UISettings::values.language.isEmpty()) {
-        //  Use the system's default locale
-        QLocale defaultLocale = QLocale::system();
-        loaded = translator.load(defaultLocale, {}, {}, QStringLiteral(":/languages/"));
+        // Use the system's default locale
+        loaded = translator.load(QLocale::system(), {}, {}, QStringLiteral(":/languages/"));
     } else {
         // Otherwise load from the specified file
         loaded = translator.load(UISettings::values.language, QStringLiteral(":/languages/"));


### PR DESCRIPTION
If there are multiple languages on a system, this fixes the annoying behavior of Citra not selecting the primary system language but the secondary one instead 

https://github.com/PabloMK7/citra/issues/74