### PR TITLE
Refactor Vulkan stream buffer memory type selection

### DIFF
--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -80,7 +80,8 @@ u32 GetMemoryType(const vk::PhysicalDeviceMemoryProperties& properties, BufferTy
     }
 
     // If we reach here, we couldn't find any suitable memory type
-    UNREACHABLE_MSG("Failed to find a suitable memory type for buffer type {}", BufferTypeName(type));
+    UNREACHABLE_MSG("Failed to find a suitable memory type for buffer type {}",
++                    BufferTypeName(type));
 }
 
 constexpr u64 WATCHES_INITIAL_RESERVE = 0x4000;

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -81,7 +81,7 @@ u32 GetMemoryType(const vk::PhysicalDeviceMemoryProperties& properties, BufferTy
 
     // If we reach here, we couldn't find any suitable memory type
     UNREACHABLE_MSG("Failed to find a suitable memory type for buffer type {}",
-+                    BufferTypeName(type));
+                    BufferTypeName(type));
 }
 
 constexpr u64 WATCHES_INITIAL_RESERVE = 0x4000;

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -33,9 +33,11 @@ vk::MemoryPropertyFlags MakePropertyFlags(BufferType type) {
     case BufferType::Upload:
         return vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
     case BufferType::Download:
-        return vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached;
+        return vk::MemoryPropertyFlagBits::eHostVisible |
+               vk::MemoryPropertyFlagBits::eHostCoherent | vk::MemoryPropertyFlagBits::eHostCached;
     case BufferType::Stream:
-        return vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible | vk::MemoryPropertyFlagBits::eHostCoherent;
+        return vk::MemoryPropertyFlagBits::eDeviceLocal | vk::MemoryPropertyFlagBits::eHostVisible |
+               vk::MemoryPropertyFlagBits::eHostCoherent;
     default:
         UNREACHABLE_MSG("Unknown buffer type {}", type);
         return vk::MemoryPropertyFlagBits::eHostVisible;
@@ -78,9 +80,7 @@ u32 GetMemoryType(const vk::PhysicalDeviceMemoryProperties& properties, BufferTy
     }
 
     // If we reach here, we couldn't find any suitable memory type
-    LOG_CRITICAL(Render_Vulkan, "Failed to find a suitable memory type for buffer type {}",
-                 BufferTypeName(type));
-    return 0; // Return 0 as a fallback, though this will likely cause issues
+    UNREACHABLE_MSG("Failed to find a suitable memory type for buffer type {}", BufferTypeName(type));
 }
 
 constexpr u64 WATCHES_INITIAL_RESERVE = 0x4000;


### PR DESCRIPTION
This is a fix for GPUs with Vulkan V1.1 and V1.2.
This Fix is merged as of now in Lime3DS and tested working (commit #384 in Lime3DS)

Fixes Issue #233 in here.