### PR TITLE
android: Fix pause emulator button crashing the emulator

### DIFF
--- a/src/android/app/src/main/jni/native.cpp
+++ b/src/android/app/src/main/jni/native.cpp
@@ -309,10 +309,12 @@ void Java_org_citra_citra_1emu_NativeLibrary_surfaceChanged(JNIEnv* env,
 
 void Java_org_citra_citra_1emu_NativeLibrary_surfaceDestroyed([[maybe_unused]] JNIEnv* env,
                                                               [[maybe_unused]] jobject obj) {
-    ANativeWindow_release(s_surf);
-    s_surf = nullptr;
-    if (window) {
-        window->OnSurfaceChanged(s_surf);
+    if (s_surf != nullptr) {
+        ANativeWindow_release(s_surf);
+        s_surf = nullptr;
+        if (window) {
+            window->OnSurfaceChanged(s_surf);
+        }
     }
 }
 


### PR DESCRIPTION
This fixes crashing if the game is paused on android
For me, Super Mario 3D Land was crashing as soon as I paused the game, but other people reported crashing after a couple paste/resume cycles anyway this should fix all pausing issues