### PR TITLE
Update `citra(6)` man page

### DIFF
--- a/dist/citra.6
+++ b/dist/citra.6
@@ -1,4 +1,4 @@
-.Dd November 22 2016
+.Dd September 13 2024
 .Dt citra 6
 .Os
 .Sh NAME
@@ -12,6 +12,20 @@
 .Bl -tag -width Ds
 .It Fl g Ar port , Fl Fl gdbport Ar port
 Starts the GDB stub on the specified port
+.It Fl i , Fl Fl install Ar FILE
+Installs a specified CIA file
+.It Fl m , Fl Fl multiplayer Ar nick:password@address:port
+Nickname, password, address and port for multiplayer
+.It Fl r , Fl Fl movie-record Ar file
+Record a movie (game inputs) to the given file
+.It Fl a , Fl Fl movie-record-author Ar AUTHOR
+Sets the author of the movie to be recorded
+.It Fl p , Fl Fl movie-play Ar file
+Playback the movie (game inputs) from the given file
+.It Fl d , Fl Fl dump-video Ar file
+Dumps audio and video to the given video file
+.It Fl f , Fl Fl fullscreen
+Start in fullscreen mode
 .It Fl h , Fl Fl help
 Shows syntax help and exits
 .It Fl v , Fl Fl version


### PR DESCRIPTION
Simple update to make the `citra` man page match the options the executable can take. Not sure where to point the web links these days, so I didn't touch those.

It now looks like this:

```
citra(6)                                                                                                  Games Manual                                                                                                 citra(6)

NAME
       Citra — Nintendo 3DS Emulator/Debugger (SDL)

SYNOPSIS
       citra [options] [file]

OPTIONS
       -g port, --gdbport port
               Starts the GDB stub on the specified port

       -i, --install FILE
               Installs a specified CIA file

       -m, --multiplayer nick:password@address:port
               Nickname, password, address and port for multiplayer

       -r, --movie-record file
               Record a movie (game inputs) to the given file

       -a, --movie-record-author AUTHOR
               Sets the author of the movie to be recorded

       -p, --movie-play file
               Playback the movie (game inputs) from the given file

       -d, --dump-video file
               Dumps audio and video to the given video file

       -f, --fullscreen
               Start in fullscreen mode

       -h, --help
               Shows syntax help and exits

       -v, --version
               Describes the installed version and exits

DESCRIPTION
       Citra is an experimental open-source Nintendo 3DS emulator/debugger.

       citra is the Simple DirectMedia Layer (SDL) implementation.

FILES
       $XDG_DATA_HOME/citra-emu
               Emulator storage.

       $XDG_CONFIG_HOME/citra-emu
               Configuration files.

AUTHORS
       This document is made available to you under the CC-BY license.

       Citra is made by a team of volunteers. These contributors are listed
        at <https://github.com/citra-emu/citra/contributors>.

SEE ALSO
       citra-qt(6)
               The Qt frontend of the application

       Resources are available for this project:

       <https://citra-emu.org>
               The main homepage of the project.

       <https://github.com/citra-emu/citra>
               The main source code repository for the Citra emulator.

GNU                                                                                                    September 13 2024                                                                                               citra(6)
```