### PR TITLE
citra_qt: Build fixes for QT 6.8

### DIFF
--- a/src/citra_qt/configuration/configure_camera.cpp
+++ b/src/citra_qt/configuration/configure_camera.cpp
@@ -9,6 +9,7 @@
 #include <QMediaDevices>
 #include <QMessageBox>
 #include <QWidget>
+#include <QtGlobal>
 #include "citra_qt/configuration/configure_camera.h"
 #include "common/settings.h"
 #include "core/frontend/camera/factory.h"
@@ -86,7 +87,11 @@ void ConfigureCamera::ConnectEvents() {
     });
     connect(ui->toolButton, &QToolButton::clicked, this, &ConfigureCamera::OnToolButtonClicked);
     connect(ui->preview_button, &QPushButton::clicked, this, [this] { StartPreviewing(); });
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->prompt_before_load, &QCheckBox::stateChanged, this, [this](int state) {
+#else
+    connect(ui->prompt_before_load, &QCheckBox::checkStateChanged, this, [this](int state) {
+#endif
         ui->camera_file->setDisabled(state == Qt::Checked);
         ui->toolButton->setDisabled(state == Qt::Checked);
         if (state == Qt::Checked) {

--- a/src/citra_qt/configuration/configure_cheats.cpp
+++ b/src/citra_qt/configuration/configure_cheats.cpp
@@ -5,6 +5,7 @@
 #include <QCheckBox>
 #include <QMessageBox>
 #include <QTableWidgetItem>
+#include <QtGlobal>
 #include "configure_cheats.h"
 #include "core/cheats/cheat_base.h"
 #include "core/cheats/cheats.h"
@@ -60,7 +61,11 @@ void ConfigureCheats::LoadCheats() {
             i, 2, new QTableWidgetItem(QString::fromStdString(cheats[i]->GetType())));
         enabled->setProperty("row", static_cast<int>(i));
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
         connect(enabled, &QCheckBox::stateChanged, this, &ConfigureCheats::OnCheckChanged);
+#else
+        connect(enabled, &QCheckBox::checkStateChanged, this, &ConfigureCheats::OnCheckChanged);
+#endif
     }
 }
 

--- a/src/citra_qt/debugger/ipc/recorder.cpp
+++ b/src/citra_qt/debugger/ipc/recorder.cpp
@@ -5,6 +5,7 @@
 #include <QBrush>
 #include <QString>
 #include <QTreeWidgetItem>
+#include <QtGlobal>
 #include <fmt/format.h>
 #include "citra_qt/debugger/ipc/record_dialog.h"
 #include "citra_qt/debugger/ipc/recorder.h"
@@ -22,8 +23,13 @@ IPCRecorderWidget::IPCRecorderWidget(Core::System& system_, QWidget* parent)
     ui->setupUi(this);
     qRegisterMetaType<IPCDebugger::RequestRecord>();
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 7, 0)
     connect(ui->enabled, &QCheckBox::stateChanged, this,
             [this](int new_state) { SetEnabled(new_state == Qt::Checked); });
+#else
+    connect(ui->enabled, &QCheckBox::checkStateChanged, this,
+            [this](int new_state) { SetEnabled(new_state == Qt::Checked); });
+#endif
     connect(ui->clearButton, &QPushButton::clicked, this, &IPCRecorderWidget::Clear);
     connect(ui->filter, &QLineEdit::textChanged, this, &IPCRecorderWidget::ApplyFilterToAll);
     connect(ui->main, &QTreeWidget::itemDoubleClicked, this, &IPCRecorderWidget::OpenRecordDialog);


### PR DESCRIPTION
QT 6.8 is scheduled to be released in the next few weeks, so it's probably a good idea to try and get ahead of that before people start complaining about compile errors.

The fix: Replace the deprecated `stateChanged` function with `checkStateChanged` that was first introduced in QT 6.7, but keep the old code to maintain compatibility with older versions of QT.