### PR TITLE
android: Make `Asynchronous shader compilation` non runtime editable

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/BooleanSetting.kt
@@ -34,7 +34,8 @@ enum class BooleanSetting(
     companion object {
         private val NOT_RUNTIME_EDITABLE = listOf(
             PLUGIN_LOADER,
-            ALLOW_PLUGIN_LOADER
+            ALLOW_PLUGIN_LOADER, 
+            ASYNC_SHADERS
         )
 
         fun from(key: String): BooleanSetting? =


### PR DESCRIPTION
I'm sure this was an oversight by the original devs and not intended to actually be runtime editable guessing by Qt's behavior

See https://github.com/Lime3DS/Lime3DS/issues/442