### PR TITLE
Reenable dpad axes option

### DIFF
--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/Settings.kt
@@ -165,9 +165,11 @@ class Settings {
             KEY_CSTICK_AXIS_VERTICAL,
             KEY_CSTICK_AXIS_HORIZONTAL
         )
-        val dPadKeys = listOf(
-//            KEY_DPAD_AXIS_VERTICAL,
-//            KEY_DPAD_AXIS_HORIZONTAL,
+        val dPadAxisKeys = listOf(
+            KEY_DPAD_AXIS_VERTICAL,
+            KEY_DPAD_AXIS_HORIZONTAL
+        )
+        val dPadButtonKeys = listOf(
             KEY_BUTTON_UP,
             KEY_BUTTON_DOWN,
             KEY_BUTTON_LEFT,

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/HeaderSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/HeaderSetting.kt
@@ -4,6 +4,6 @@
 
 package org.citra.citra_emu.features.settings.model.view
 
-class HeaderSetting(titleId: Int) : SettingsItem(null, titleId, 0) {
+class HeaderSetting(titleId: Int,descId: Int = 0) : SettingsItem(null, titleId, descId) {
     override val type = TYPE_HEADER
 }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -136,7 +136,6 @@ class InputBindingSetting(
                 Settings.KEY_BUTTON_DOWN -> NativeLibrary.ButtonType.DPAD_DOWN
                 Settings.KEY_BUTTON_LEFT -> NativeLibrary.ButtonType.DPAD_LEFT
                 Settings.KEY_BUTTON_RIGHT -> NativeLibrary.ButtonType.DPAD_RIGHT
-
                 Settings.HOTKEY_SCREEN_SWAP -> Hotkey.SWAP_SCREEN.button
                 Settings.HOTKEY_CYCLE_LAYOUT -> Hotkey.CYCLE_LAYOUT.button
                 Settings.HOTKEY_CLOSE_GAME -> Hotkey.CLOSE_GAME.button

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/model/view/InputBindingSetting.kt
@@ -78,15 +78,6 @@ class InputBindingSetting(
 
             else -> false
         }
-
-    fun isDpadButtons(): Boolean =
-        when (abstractSetting.key) {
-            Settings.KEY_BUTTON_DOWN,
-            Settings.KEY_BUTTON_LEFT,
-            Settings.KEY_BUTTON_UP,
-            Settings.KEY_BUTTON_RIGHT -> true
-            else -> false
-        }
     /**
      * Returns true if this key is for the 3DS L/R or ZL/ZR buttons. Note, these are not real
      * triggers on the 3DS, but we support them as such on a physical gamepad.

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivity.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsActivity.kt
@@ -191,7 +191,7 @@ class SettingsActivity : AppCompatActivity(), SettingsActivityView {
         presenter.onSettingsReset()
 
         val controllerKeys = Settings.buttonKeys + Settings.circlePadKeys + Settings.cStickKeys +
-                Settings.dPadKeys + Settings.triggerKeys
+                Settings.dPadButtonKeys + Settings.dPadAxisKeys + Settings.triggerKeys
         val editor =
             PreferenceManager.getDefaultSharedPreferences(CitraApplication.appContext).edit()
         controllerKeys.forEach { editor.remove(it) }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -621,8 +621,13 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 add(InputBindingSetting(button, Settings.axisTitles[i]))
             }
 
-            add(HeaderSetting(R.string.controller_dpad))
-            Settings.dPadKeys.forEachIndexed { i: Int, key: String ->
+            add(HeaderSetting(R.string.controller_dpad_axis))
+            Settings.dPadAxisKeys.forEachIndexed { i: Int, key: String ->
+                val button = getInputObject(key)
+                add(InputBindingSetting(button, Settings.axisTitles[i]))
+            }
+            add(HeaderSetting(R.string.controller_dpad_button))
+            Settings.dPadButtonKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.dPadTitles[i]))
             }

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/SettingsFragmentPresenter.kt
@@ -621,12 +621,12 @@ class SettingsFragmentPresenter(private val fragmentView: SettingsFragmentView) 
                 add(InputBindingSetting(button, Settings.axisTitles[i]))
             }
 
-            add(HeaderSetting(R.string.controller_dpad_axis))
+            add(HeaderSetting(R.string.controller_dpad_axis,R.string.controller_dpad_axis_description))
             Settings.dPadAxisKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.axisTitles[i]))
             }
-            add(HeaderSetting(R.string.controller_dpad_button))
+            add(HeaderSetting(R.string.controller_dpad_button,R.string.controller_dpad_button_description))
             Settings.dPadButtonKeys.forEachIndexed { i: Int, key: String ->
                 val button = getInputObject(key)
                 add(InputBindingSetting(button, Settings.dPadTitles[i]))

--- a/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/HeaderViewHolder.kt
+++ b/src/android/app/src/main/java/org/citra/citra_emu/features/settings/ui/viewholder/HeaderViewHolder.kt
@@ -18,6 +18,12 @@ class HeaderViewHolder(val binding: ListItemSettingsHeaderBinding, adapter: Sett
 
     override fun bind(item: SettingsItem) {
         binding.textHeaderName.setText(item.nameId)
+        if (item.descriptionId != 0) {
+            binding.textHeaderDescription.visibility = View.VISIBLE
+            binding.textHeaderDescription.setText(item.descriptionId)
+        }else {
+            binding.textHeaderDescription.visibility = View.GONE
+        }
     }
 
     override fun onClick(clicked: View) {

--- a/src/android/app/src/main/res/layout/list_item_settings_header.xml
+++ b/src/android/app/src/main/res/layout/list_item_settings_header.xml
@@ -1,16 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.textview.MaterialTextView xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:focusable="false"
+    android:clickable="false"
+    android:paddingVertical="16dp"
+        >
+
+<com.google.android.material.textview.MaterialTextView
+
     android:id="@+id/text_header_name"
     style="@style/TextAppearance.Material3.TitleSmall"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="start|center_vertical"
-    android:paddingHorizontal="@dimen/spacing_large"
-    android:paddingVertical="16dp"
-    android:focusable="false"
-    android:clickable="false"
     android:textAlignment="viewStart"
     android:textColor="?attr/colorPrimary"
     android:textStyle="bold"
     tools:text="CPU Settings" />
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/text_header_description"
+        style="@style/TextAppearance.Material3.BodySmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/spacing_small"
+        android:textAlignment="viewStart"
+        tools:text="@string/app_disclaimer" />
+</LinearLayout>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -108,6 +108,8 @@
     <string name="controller_triggers">Triggers</string>
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>
+    <string name="controller_dpad_axis">D-Pad (Axis)</string>
+    <string name="controller_dpad_button">D-Pad (Buttons)</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>

--- a/src/android/app/src/main/res/values/strings.xml
+++ b/src/android/app/src/main/res/values/strings.xml
@@ -109,7 +109,9 @@
     <string name="controller_trigger">Trigger</string>
     <string name="controller_dpad">D-Pad</string>
     <string name="controller_dpad_axis">D-Pad (Axis)</string>
+    <string name="controller_dpad_axis_description">Some controllers will not be able to map their dpad as an axis. In that case, use the D-Pad (buttons) section below instead.</string>
     <string name="controller_dpad_button">D-Pad (Buttons)</string>
+    <string name="controller_dpad_button_description">Only map these buttons if the D-Pad (Axis) settings above do not work with your controller.</string>
     <string name="controller_axis_vertical">Up/Down Axis</string>
     <string name="controller_axis_horizontal">Left/Right Axis</string>
     <string name="direction_up">Up</string>


### PR DESCRIPTION
Closes #255 by re-enabling the Dpad Axes as an option for controllers where the buttons aren't being detected. This code already existed in an earlier version of this, I'm just adding it back, but the new code is essentially identical to the code in Lime3DS so credit to those developers.

I am still looking into why the buttons don't work even when mapped in situations where an axis is also detected (Lime3DS has this issue as well), I will try to put in a hotfix for that eventually for maximum flexibility, but in the meantime this works.

There is a cleaner solution to this that I'd like to implement eventually, but this should at least make it functional for all.
