### PR TITLE
Match changes to svcMapProcessMemoryEx from latest Luma3DS

### DIFF
--- a/src/core/file_sys/plugin_3gx.h
+++ b/src/core/file_sys/plugin_3gx.h
@@ -94,6 +94,9 @@ private:
             BitField<1, 1, u32_le> embedded_swap_func;
             BitField<2, 2, u32_le> memory_region_size;
             BitField<4, 2, u32_le> compatibility;
+            BitField<6, 1, u32_le> events_self_managed;
+            BitField<7, 1, u32_le> swap_not_needed;
+            BitField<8, 1, u32_le> use_private_memory;
         } flags;
         u32_le exe_load_checksum;
         u32_le builtin_load_exe_args[4];

--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -38,7 +38,7 @@ SERVICE_CONSTRUCT_IMPL(Service::PLGLDR::PLG_LDR)
 
 namespace Service::PLGLDR {
 
-static const Kernel::CoreVersion plgldr_version = Kernel::CoreVersion(1, 0, 0);
+static const Kernel::CoreVersion plgldr_version = Kernel::CoreVersion(1, 0, 2);
 
 PLG_LDR::PLG_LDR(Core::System& system_) : ServiceFramework{"plg:ldr", 1}, system(system_) {
     static const FunctionInfo functions[] = {


### PR DESCRIPTION
Allows mapping memory regions with the PRIVATE state instead of the SHARED state.