### PR TITLE
Make plugins only load for apps and not applets

### DIFF
--- a/src/core/hle/service/plgldr/plgldr.cpp
+++ b/src/core/hle/service/plgldr/plgldr.cpp
@@ -91,7 +91,11 @@ void PLG_LDR::serialize(Archive& ar, const unsigned int) {
 SERIALIZE_IMPL(PLG_LDR)
 
 void PLG_LDR::OnProcessRun(Kernel::Process& process, Kernel::KernelSystem& kernel) {
-    if (!plgldr_context.is_enabled || plgldr_context.plugin_loaded) {
+    constexpr u32 TITLE_ID_APP_MASK = 0xFFFFFFED;
+    constexpr u32 TITLE_ID_APP_VALUE = 0x04000000;
+    if (!plgldr_context.is_enabled || plgldr_context.plugin_loaded ||
+        (static_cast<u32>(process.codeset->program_id >> 32) & TITLE_ID_APP_MASK) !=
+            TITLE_ID_APP_VALUE) {
         return;
     }
     {


### PR DESCRIPTION
Fixes plugins incorrectly loading when applets are launched.